### PR TITLE
Begin adding JSDocs to the project

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -79,7 +79,7 @@
 
   "rules": {
     "indent": ["error", "tab"],      // indent tabs
-    "no-tabs": "off",                    // allows tabs at all
+    "no-tabs": "off",                // allows tabs at all
     "comma-dangle": 0,               // disallow trailing commas in object literals
     "no-cond-assign": 1,             // disallow assignment in conditional expressions
     "no-console": 0,                 // disallow use of console (off by default in the node environment)

--- a/.eslintrc
+++ b/.eslintrc
@@ -79,6 +79,7 @@
 
   "rules": {
     "indent": ["error", "tab"],      // indent tabs
+    "no-tabs": "off",                    // allows tabs at all
     "comma-dangle": 0,               // disallow trailing commas in object literals
     "no-cond-assign": 1,             // disallow assignment in conditional expressions
     "no-console": 0,                 // disallow use of console (off by default in the node environment)
@@ -101,7 +102,7 @@
     "no-sparse-arrays": 1,           // disallow sparse arrays
     "no-unreachable": 1,             // disallow unreachable statements after a return, throw, continue, or break statement
     "use-isnan": 1,                  // disallow comparisons with the value NaN
-    "valid-jsdoc": 0,                // Ensure JSDoc comments are valid (off by default)
+    "valid-jsdoc": 1,                // Ensure JSDoc comments are valid (off by default)
     "valid-typeof": 1,               // Ensure that the results of typeof are compared against a valid string
     linebreak-style: 0,              // git already manages our line endings :-O
   // Best Practices

--- a/app/util/general.js
+++ b/app/util/general.js
@@ -1,8 +1,3 @@
-/**
- * A module containing general helper functions
- * @module general
- */
-
 import {
 	Animated,
 	Easing,
@@ -14,11 +9,15 @@ import {
 const dateFormat = require('dateformat');
 const logger = require('./logger');
 
+/**
+ * A module containing general helper functions
+ * @module util/general
+ */
 module.exports = {
 
 	/**
+	 * Gets whether or not the current platform the app is running on is IOS
 	 * @function platformIOS
-	 * @description Gets whether or not the current platform the app is running on is IOS
 	 * @returns {boolean} True if the platform is IOS, false otherwise
 	 */
 	platformIOS() {
@@ -26,8 +25,8 @@ module.exports = {
 	},
 
 	/**
+	 * Gets whether or not the current platform the app is running on is Android
 	 * @function platformAndroid
-	 * @description Gets whether or not the current platform the app is running on is Android
 	 * @returns {boolean} True if the platform is Android, false otherwise
 	 */
 	platformAndroid() {
@@ -35,8 +34,8 @@ module.exports = {
 	},
 
 	/**
+	 * Gets the current platform ths app is running on
 	 * @function getPlatform
-	 * @description Gets the current platform ths app is running on
 	 * @returns {string} The platform name
 	 */
 	getPlatform() {
@@ -44,9 +43,9 @@ module.exports = {
 	},
 
 	/**
+	 * Converts a numerical quantity from meters to miles
 	 * @function convertMetersToMiles
-	 * @description Converts a numerical quantity from meters to miles
-	 * @param {number} meters - The quantity to convert
+	 * @param {number} meters The quantity to convert
 	 * @returns {number} The quantity now converted into miles
 	 */
 	convertMetersToMiles(meters) {
@@ -54,9 +53,9 @@ module.exports = {
 	},
 
 	/**
+	 * Gets a string representation of a given quantity of miles (up to and including a single decimal place)
 	 * @function getDistanceMilesStr
-	 * @description Gets a string representation of a given quantity of miles (up to and including a single decimal place)
-	 * @param {number} miles - The quantity to convert to a string
+	 * @param {number} miles The quantity to convert to a string
 	 * @returns {number} The miles quantity now as a string
 	 */
 	getDistanceMilesStr(miles) {
@@ -64,9 +63,9 @@ module.exports = {
 	},
 
 	/**
+	 * Attempts to open the provided URL for displaying to the user
 	 * @function openURL
-	 * @description Attempts to open the provided URL for displaying to the user
-	 * @param {string} url - The URL to open
+	 * @param {string} url The URL to open
 	 * @returns {boolean|undefined} If the URL cannot be opened, this logs to console. Otherwise, returns true.
 	 * False can only be returned if the ability to open a URL changes between the check and the opening itself.
 	 * @todo Develop a more explicit/consistent return for this method
@@ -82,11 +81,11 @@ module.exports = {
 	},
 
 	/**
+	 * Gets the URL for obtaining directions to a given location via a given transportation method
 	 * @function getDirectionsURL
-	 * @description Gets the URL for obtaining directions to a given location via a given transportation method
-	 * @param {string} method - Can be "walk" or anything else. Anything else will result in a URL for driving.
-	 * @param {string|number} stopLat - The latitude of the destination
-	 * @param {string|number} stopLon - The longitude of the destination
+	 * @param {string} method Can be "walk" or anything else. Anything else will result in a URL for driving.
+	 * @param {string|number} stopLat The latitude of the destination
+	 * @param {string|number} stopLon The longitude of the destination
 	 * @return {string} A platform-specific URL for obtaining the directions
 	 */
 	getDirectionsURL(method, stopLat, stopLon) {
@@ -156,8 +155,8 @@ module.exports = {
 	},
 
 	/**
-	 * @function getCampusPrimary
 	 * Gets the UCSD campus primary color in hexidecimal form
+	 * @function getCampusPrimary
 	 * @returns {string} The string "#182B49" which represents a dark blue color
 	 */
 	getCampusPrimary() {
@@ -230,8 +229,8 @@ module.exports = {
 	},
 
 	/**
+	 * Generates random color hex
 	 * @function getRandomColor
-	 * @description Generates random color hex
 	 * @returns {string} A randomly generated hex color code
 	 */
 	getRandomColor() {

--- a/app/util/general.js
+++ b/app/util/general.js
@@ -23,14 +23,31 @@ module.exports = {
 		return Platform.OS;
 	},
 
+	/**
+	 * Converts a numerical quantity from meters to miles
+	 * @param {number} meters - The quantity to convert
+	 * @returns {number} The quantity now converted into miles
+	 */
 	convertMetersToMiles(meters) {
 		return (meters / 1609.344);
 	},
 
+	/**
+	 * Gets a string representation of a given quantity of miles (up to and including a single decimal place)
+	 * @param {number} miles - The quantity to convert to a string
+	 * @returns {number} The miles quantity now as a string
+	 */
 	getDistanceMilesStr(miles) {
 		return (miles.toFixed(1) + ' mi');
 	},
 
+	/**
+	 * Attempts to open the provided URL for displaying to the user
+	 * @param {string} url - The URL to open
+	 * @returns {boolean|undefined} If the URL cannot be opened, this logs to console. Otherwise, returns true.
+	 * False can only be returned if the ability to open a URL changes between the check and the opening itself.
+	 * @todo Develop a more explicit/consistent return for this method
+	 */
 	openURL(url) {
 		Linking.canOpenURL(url).then(supported => {
 			if (!supported) {
@@ -41,6 +58,13 @@ module.exports = {
 		}).catch(err => logger.log('ERR: openURL: ' + err));
 	},
 
+	/**
+	 * Gets the URL for obtaining directions to a given location via a given transportation method
+	 * @param {string} method - Can be "walk" or anything else. Anything else will result in a URL for driving.
+	 * @param {string|number} stopLat - The latitude of the destination
+	 * @param {string|number} stopLon - The longitude of the destination
+	 * @return {string} A platform-specific URL for obtaining the directions
+	 */
 	getDirectionsURL(method, stopLat, stopLon) {
 		let directionsURL;
 
@@ -107,6 +131,10 @@ module.exports = {
 		return windowWidth - 2 - 12;
 	},
 
+	/**
+	 * Gets the UCSD campus primary color in hexidecimal form
+	 * @returns {string} The string "#182B49" which represents a dark blue color
+	 */
 	getCampusPrimary() {
 		return '#182B49';
 	},
@@ -176,7 +204,10 @@ module.exports = {
 		return randomColors;
 	},
 
-	// Generates random color hex
+	/**
+	 * Generates random color hex
+	 * @returns {string} A randomly generated hex color code
+	 */
 	getRandomColor() {
 		return '#' + ('000000' + Math.random().toString(16).slice(2, 8).toUpperCase()).slice(-6);
 	},

--- a/app/util/general.js
+++ b/app/util/general.js
@@ -11,14 +11,26 @@ const logger = require('./logger');
 
 module.exports = {
 
+	/**
+	 * Gets whether or not the current platform the app is running on is IOS
+	 * @returns {boolean} True if the platform is IOS, false otherwise
+	 */
 	platformIOS() {
 		return Platform.OS === 'ios';
 	},
 
+	/**
+	 * Gets whether or not the current platform the app is running on is Android
+	 * @returns {boolean} True if the platform is Android, false otherwise
+	 */
 	platformAndroid() {
 		return Platform.OS === 'android';
 	},
 
+	/**
+	 * Gets the current platform ths app is running on
+	 * @returns {string} The platform name
+	 */
 	getPlatform() {
 		return Platform.OS;
 	},

--- a/app/util/general.js
+++ b/app/util/general.js
@@ -1,3 +1,8 @@
+/**
+ * A module containing general helper functions
+ * @module general
+ */
+
 import {
 	Animated,
 	Easing,
@@ -12,7 +17,8 @@ const logger = require('./logger');
 module.exports = {
 
 	/**
-	 * Gets whether or not the current platform the app is running on is IOS
+	 * @function platformIOS
+	 * @description Gets whether or not the current platform the app is running on is IOS
 	 * @returns {boolean} True if the platform is IOS, false otherwise
 	 */
 	platformIOS() {
@@ -20,7 +26,8 @@ module.exports = {
 	},
 
 	/**
-	 * Gets whether or not the current platform the app is running on is Android
+	 * @function platformAndroid
+	 * @description Gets whether or not the current platform the app is running on is Android
 	 * @returns {boolean} True if the platform is Android, false otherwise
 	 */
 	platformAndroid() {
@@ -28,7 +35,8 @@ module.exports = {
 	},
 
 	/**
-	 * Gets the current platform ths app is running on
+	 * @function getPlatform
+	 * @description Gets the current platform ths app is running on
 	 * @returns {string} The platform name
 	 */
 	getPlatform() {
@@ -36,7 +44,8 @@ module.exports = {
 	},
 
 	/**
-	 * Converts a numerical quantity from meters to miles
+	 * @function convertMetersToMiles
+	 * @description Converts a numerical quantity from meters to miles
 	 * @param {number} meters - The quantity to convert
 	 * @returns {number} The quantity now converted into miles
 	 */
@@ -45,7 +54,8 @@ module.exports = {
 	},
 
 	/**
-	 * Gets a string representation of a given quantity of miles (up to and including a single decimal place)
+	 * @function getDistanceMilesStr
+	 * @description Gets a string representation of a given quantity of miles (up to and including a single decimal place)
 	 * @param {number} miles - The quantity to convert to a string
 	 * @returns {number} The miles quantity now as a string
 	 */
@@ -54,7 +64,8 @@ module.exports = {
 	},
 
 	/**
-	 * Attempts to open the provided URL for displaying to the user
+	 * @function openURL
+	 * @description Attempts to open the provided URL for displaying to the user
 	 * @param {string} url - The URL to open
 	 * @returns {boolean|undefined} If the URL cannot be opened, this logs to console. Otherwise, returns true.
 	 * False can only be returned if the ability to open a URL changes between the check and the opening itself.
@@ -71,7 +82,8 @@ module.exports = {
 	},
 
 	/**
-	 * Gets the URL for obtaining directions to a given location via a given transportation method
+	 * @function getDirectionsURL
+	 * @description Gets the URL for obtaining directions to a given location via a given transportation method
 	 * @param {string} method - Can be "walk" or anything else. Anything else will result in a URL for driving.
 	 * @param {string|number} stopLat - The latitude of the destination
 	 * @param {string|number} stopLon - The longitude of the destination
@@ -144,6 +156,7 @@ module.exports = {
 	},
 
 	/**
+	 * @function getCampusPrimary
 	 * Gets the UCSD campus primary color in hexidecimal form
 	 * @returns {string} The string "#182B49" which represents a dark blue color
 	 */
@@ -217,7 +230,8 @@ module.exports = {
 	},
 
 	/**
-	 * Generates random color hex
+	 * @function getRandomColor
+	 * @description Generates random color hex
 	 * @returns {string} A randomly generated hex color code
 	 */
 	getRandomColor() {

--- a/app/util/general.js
+++ b/app/util/general.js
@@ -17,7 +17,7 @@ module.exports = {
 
 	/**
 	 * Gets whether or not the current platform the app is running on is IOS
-	 * @function platformIOS
+	 * @function
 	 * @returns {boolean} True if the platform is IOS, false otherwise
 	 */
 	platformIOS() {
@@ -26,7 +26,7 @@ module.exports = {
 
 	/**
 	 * Gets whether or not the current platform the app is running on is Android
-	 * @function platformAndroid
+	 * @function
 	 * @returns {boolean} True if the platform is Android, false otherwise
 	 */
 	platformAndroid() {
@@ -35,7 +35,7 @@ module.exports = {
 
 	/**
 	 * Gets the current platform ths app is running on
-	 * @function getPlatform
+	 * @function
 	 * @returns {string} The platform name
 	 */
 	getPlatform() {
@@ -44,7 +44,7 @@ module.exports = {
 
 	/**
 	 * Converts a numerical quantity from meters to miles
-	 * @function convertMetersToMiles
+	 * @function
 	 * @param {number} meters The quantity to convert
 	 * @returns {number} The quantity now converted into miles
 	 */
@@ -54,7 +54,7 @@ module.exports = {
 
 	/**
 	 * Gets a string representation of a given quantity of miles (up to and including a single decimal place)
-	 * @function getDistanceMilesStr
+	 * @function
 	 * @param {number} miles The quantity to convert to a string
 	 * @returns {number} The miles quantity now as a string
 	 */
@@ -64,7 +64,7 @@ module.exports = {
 
 	/**
 	 * Attempts to open the provided URL for displaying to the user
-	 * @function openURL
+	 * @function
 	 * @param {string} url The URL to open
 	 * @returns {boolean|undefined} If the URL cannot be opened, this logs to console. Otherwise, returns true.
 	 * False can only be returned if the ability to open a URL changes between the check and the opening itself.
@@ -82,7 +82,7 @@ module.exports = {
 
 	/**
 	 * Gets the URL for obtaining directions to a given location via a given transportation method
-	 * @function getDirectionsURL
+	 * @function
 	 * @param {string} method Can be "walk" or anything else. Anything else will result in a URL for driving.
 	 * @param {string|number} stopLat The latitude of the destination
 	 * @param {string|number} stopLon The longitude of the destination
@@ -111,27 +111,66 @@ module.exports = {
 		return directionsURL;
 	},
 
+	/**
+	 * Attempts to redirect the device to its navigation app
+	 * @function
+	 * @param {string} method Currently not used, can be anything
+	 * @param {string|number} destinationLat The destination's latitude
+	 * @param {string|number} destinationLon The destination's longitude
+	 * @todo Either use the "method" parameter or remove it from the declaration
+	 */
 	gotoNavigationApp(method, destinationLat, destinationLon) {
 		const destinationURL = this.getDirectionsURL('walk', destinationLat, destinationLon );
 		this.openURL(destinationURL);
 	},
 
+	/**
+	 * Begins the app's reloading animation with specific parameters
+	 * @function
+	 * @param {View|Text|Image|Object} anim The animation to use
+	 * @param {number} toVal The value to approach
+	 * @param {number} duration The duration of the animation
+	 */
 	startReloadAnimation2(anim, toVal, duration) {
 		Animated.timing(anim, { toValue: toVal, duration, easing: Easing.linear }).start();
 	},
 
+	/**
+	 * Begins the app's reloading animation
+	 * @function
+	 * @param {View|Text|Image|Object} anim The animation to use
+	 */
 	startReloadAnimation(anim) {
 		Animated.timing(anim, { toValue: 100, duration: 60000, easing: Easing.linear }).start();
 	},
 
+	/**
+	 * Stops the specified reload animation
+	 * @function
+	 * @param {View|Text|Image|Object} anim The animation to stop
+	 */
 	stopReloadAnimation(anim) {
 		Animated.timing(anim, { toValue: 0, duration: 0 }).start();
 	},
 
+	/**
+	 * Rounds a number to the nearest integer
+	 * As examples: 2.49 will be rounded down to 2, while 2.5 will be rounded up to 3
+	 * @function
+	 * @param {number} number The number to round
+	 * @returns {number} The rounded number
+	 */
 	round(number) {
 		return Math.round(number);
 	},
 
+	/**
+	 * Gets the pixel-ratio-modifier needed for this device window
+	 * The modifier is a ratio to be used for scaling GUI elements based on the default sizes
+	 * @function
+	 * @returns {number} The ratio of current window width vs the app's default width
+	 * @todo The variable windowHeight is unused
+	 */
 	getPRM() {
 		const windowWidth = Dimensions.get('window').width;
 		const windowHeight = Dimensions.get('window').height;
@@ -139,6 +178,14 @@ module.exports = {
 		return (windowWidth / appDefaultWidth);
 	},
 
+	/**
+	 * Modifies the input value by the pixel-ration-modifier
+	 * This can be used to scale a GUI element's size for the current device
+	 * @function
+	 * @param {number} num The number/size to scale
+	 * @returns {number} The now-scaled number/size
+	 * @todo This method could call this.getPRM() to prevent redundant code
+	 */
 	doPRM(num) {
 		const windowWidth = Dimensions.get('window').width;
 		const appDefaultWidth = 414;
@@ -147,6 +194,11 @@ module.exports = {
 		return Math.round(num * prm);
 	},
 
+	/**
+	 * Gets the maximum width for a card occupying a screen/window
+	 * @function
+	 * @returns {number} The maximum width in pixels
+	 */
 	getMaxCardWidth() {
 		const windowSize = Dimensions.get('window');
 		const windowWidth = windowSize.width;
@@ -156,29 +208,56 @@ module.exports = {
 
 	/**
 	 * Gets the UCSD campus primary color in hexidecimal form
-	 * @function getCampusPrimary
+	 * @function
 	 * @returns {string} The string "#182B49" which represents a dark blue color
 	 */
 	getCampusPrimary() {
 		return '#182B49';
 	},
 
+	/**
+	 * Gets the current timestamp in seconds
+	 * @function
+	 * @returns {number} The number of seconds since midnight Jan 1, 1970
+	 */
 	getCurrentTimestamp() {
 		return Math.round(Date.now() / 1000);
 	},
 
+	/**
+	 * Gets the current timestamp formatted as a string
+	 * @function
+	 * @returns {string} The current time formatted to "yyyymmdd"
+	 */
 	getTimestampNumeric() {
 		return (dateFormat(Date.now(), 'yyyymmdd'));
 	},
 
+	/**
+	 * Gets the current timestamp in a specified format
+	 * @function
+	 * @param {string} The format to use (e.g. "yyyymmdd")
+	 * @returns {string} The formatted current time
+	 */
 	getTimestamp(format) {
 		return (dateFormat(Date.now(), format));
 	},
 
+	/**
+	 * Gets the current date
+	 * @function
+	 * @returns {number} The number of milliseconds since midnight Jan 1, 1970
+	 */
 	getDateNow() {
 		return (Date.now());
 	},
 
+	/**
+	 * Converts a time string provided in military form to AM-PM form
+	 * @function
+	 * @param {string} The time in military form
+	 * @returns {string} The time in AM-PM form
+	 */
 	militaryToAMPM(time) {
 		let militaryTime = time.substring(0, 5).replace(':','');
 		let militaryTimeHH,
@@ -220,6 +299,12 @@ module.exports = {
 		}
 	},
 
+	/**
+	 * Gets an array containing random colors
+	 * @function
+	 * @param {number} length The length of the array to return
+	 * @returns {number[]} An array with each element containing a randomly generated hex color code
+	 */
 	getRandomColorArray(length) {
 		const randomColors = [];
 		for (let i = 0; i < length; ++i) {
@@ -230,19 +315,35 @@ module.exports = {
 
 	/**
 	 * Generates random color hex
-	 * @function getRandomColor
+	 * @function
 	 * @returns {string} A randomly generated hex color code
 	 */
 	getRandomColor() {
 		return '#' + ('000000' + Math.random().toString(16).slice(2, 8).toUpperCase()).slice(-6);
 	},
 
+	/**
+	 * Gets a linear sorting function based on a given property of the input objects
+	 * @function
+	 * @param {string} property The property the sorting function should concern itself with
+	 * @returns {function} A sorting function that compares inputs based on one of their properties 
+	 */
 	dynamicSort(property) {
 		return function(a, b) {
 			return (a[property] < b[property]) ? -1 : (a[property] > b[property]) ? 1 : 0;
 		}
 	},
 
+	/**
+	 * This is a comparison function used for sorting markers
+	 * @function
+	 * @param {Object} a The first marker to compare
+	 * @param {number} a.distance The first distance
+	 * @param {Object} b The second marker to compare
+	 * @param {number} b.distance The second distance
+	 * @return {number} -1 if a is less-than b, 0 if they are equal, 1 if a is greater-then b
+	 * @todo This function is already handled by the one returned by dynamicSort()
+	 */
 	sortNearbyMarkers(a, b) {
 		if (a.distance < b.distance) {
 			return -1;

--- a/app/util/logger.js
+++ b/app/util/logger.js
@@ -5,10 +5,19 @@ GoogleAnalytics.setTrackerId(AppSettings.GOOGLE_ANALYTICS_ID);
 
 module.exports = {
 
+	/**
+	 * Send a log message to the console
+	 * @param {string} msg - The message to log
+	 */
 	log(msg) {
 		console.log(msg);
 	},
 
+	/**
+	 * Send an error message to the console
+	 * If debugging is enabled, the message is sent as an error (e.g. stderr)
+	 * @param {string} msg The error message to log
+	 */
 	error(msg) {
 		if (AppSettings.DEBUG_ENABLED) {
 			console.error(msg);

--- a/app/util/logger.js
+++ b/app/util/logger.js
@@ -3,11 +3,16 @@ const GoogleAnalytics = require('react-native-google-analytics-bridge');
 
 GoogleAnalytics.setTrackerId(AppSettings.GOOGLE_ANALYTICS_ID);
 
+/**
+ * A module containing logging helper functions
+ * @module util/logger
+ */
 module.exports = {
 
 	/**
 	 * Send a log message to the console
-	 * @param {string} msg - The message to log
+	 * @function log
+	 * @param {string} msg The message to log
 	 */
 	log(msg) {
 		console.log(msg);
@@ -16,7 +21,8 @@ module.exports = {
 	/**
 	 * Send an error message to the console
 	 * If debugging is enabled, the message is sent as an error (e.g. stderr)
-	 * @param {string} msg - The error message to log
+	 * @function error
+	 * @param {string} msg The error message to log
 	 */
 	error(msg) {
 		if (AppSettings.DEBUG_ENABLED) {
@@ -28,7 +34,8 @@ module.exports = {
 
 	/**
 	 * Sends a log message to Google Analytics as well as the local console
-	 * @param {string} msg - The message to to log
+	 * @function ga
+	 * @param {string} msg The message to to log
 	 */
 	ga(msg) {
 		this.log(msg);

--- a/app/util/logger.js
+++ b/app/util/logger.js
@@ -16,7 +16,7 @@ module.exports = {
 	/**
 	 * Send an error message to the console
 	 * If debugging is enabled, the message is sent as an error (e.g. stderr)
-	 * @param {string} msg The error message to log
+	 * @param {string} msg - The error message to log
 	 */
 	error(msg) {
 		if (AppSettings.DEBUG_ENABLED) {
@@ -26,6 +26,10 @@ module.exports = {
 		}
 	},
 
+	/**
+	 * Sends a log message to Google Analytics as well as the local console
+	 * @param {string} msg - The message to to log
+	 */
 	ga(msg) {
 		this.log(msg);
 		GoogleAnalytics.trackScreenView(msg);

--- a/app/util/logger.js
+++ b/app/util/logger.js
@@ -11,7 +11,7 @@ module.exports = {
 
 	/**
 	 * Send a log message to the console
-	 * @function log
+	 * @function
 	 * @param {string} msg The message to log
 	 */
 	log(msg) {
@@ -21,7 +21,7 @@ module.exports = {
 	/**
 	 * Send an error message to the console
 	 * If debugging is enabled, the message is sent as an error (e.g. stderr)
-	 * @function error
+	 * @function
 	 * @param {string} msg The error message to log
 	 */
 	error(msg) {
@@ -34,7 +34,7 @@ module.exports = {
 
 	/**
 	 * Sends a log message to Google Analytics as well as the local console
-	 * @function ga
+	 * @function
 	 * @param {string} msg The message to to log
 	 */
 	ga(msg) {

--- a/app/util/map.js
+++ b/app/util/map.js
@@ -16,14 +16,19 @@ Math.degrees = function (radians) {
 	return (radians * 180) / Math.PI;
 };
 
+/**
+ * A module containing map-related helper functions
+ * @module util/map
+ */
 module.exports = {
 
 	/**
 	 * Gets the surface distance between two Earth coordinates in meters
-	 * @param {number} lat1 - The latitude of the first point
-	 * @param {number} lon1 - The longitude of the first point
-	 * @param {number} lat2 - The latitude of the second point
-	 * @param {number} lon2 - The longitude of the second point
+	 * @function getDistance
+	 * @param {number} lat1 The latitude of the first point
+	 * @param {number} lon1 The longitude of the first point
+	 * @param {number} lat2 The latitude of the second point
+	 * @param {number} lon2 The longitude of the second point
 	 * @return {number|null} Null if any of the inputs were null. Otherwise, the distance in meters (rounded down the nearest integer)
 	 */
 	getDistance(lat1, lon1, lat2, lon2) {
@@ -43,10 +48,11 @@ module.exports = {
 
 	/**
 	 * Gets the coordinates of the midpoint between two coordinates
-	 * @param {number} lat1 - The latitude of the first point
-	 * @param {number} lon1 - The longitude of the first point
-	 * @param {number} lat2 - The latitude of the second point
-	 * @param {number} lon2 - The longitude of the second point
+	 * @function getMidpointCoords
+	 * @param {number} lat1 The latitude of the first point
+	 * @param {number} lon1 The longitude of the first point
+	 * @param {number} lat2 The latitude of the second point
+	 * @param {number} lon2 The longitude of the second point
 	 * @returns {number[]} The midpoint coordinates stored in a 2-length array with the form {latitude, longitude}
 	 */
 	getMidpointCoords(lat1, lon1, lat2, lon2) {

--- a/app/util/map.js
+++ b/app/util/map.js
@@ -1,17 +1,32 @@
-// Converts from degrees to radians
+/**
+ * Converts from degrees to radians
+ * @param {number} degrees - The quantity in degrees
+ * @return {number} The quantity, now in radians
+ */
 Math.radians = function (degrees) {
 	return (degrees * Math.PI) / 180;
 };
 
-// Converts from radians to degrees
+/**
+ * Converts from radians to degrees
+ * @param {number} radians - The quantity in radians
+ * @return {number} The quantity, now in degrees
+ */
 Math.degrees = function (radians) {
 	return (radians * 180) / Math.PI;
 };
 
 module.exports = {
 
+	/**
+	 * Gets the surface distance between two Earth coordinates in meters
+	 * @param {number} lat1 - The latitude of the first point
+	 * @param {number} lon1 - The longitude of the first point
+	 * @param {number} lat2 - The latitude of the second point
+	 * @param {number} lon2 - The longitude of the second point
+	 * @return {number|null} Null if any of the inputs were null. Otherwise, the distance in meters (rounded down the nearest integer)
+	 */
 	getDistance(lat1, lon1, lat2, lon2) {
-
 		if (lat1 && lon1 && lat2 && lon2) {
 			const Phi1 = Math.radians(lat1);
 			const Phi2 = Math.radians(lat2);
@@ -26,6 +41,14 @@ module.exports = {
 		}
 	},
 
+	/**
+	 * Gets the coordinates of the midpoint between two coordinates
+	 * @param {number} lat1 - The latitude of the first point
+	 * @param {number} lon1 - The longitude of the first point
+	 * @param {number} lat2 - The latitude of the second point
+	 * @param {number} lon2 - The longitude of the second point
+	 * @returns {number[]} The midpoint coordinates stored in a 2-length array with the form {latitude, longitude}
+	 */
 	getMidpointCoords(lat1, lon1, lat2, lon2) {
 		if (lat1 && lon1 && lat2 && lon2) {
 			lat1 = Math.radians(lat1);

--- a/app/util/map.js
+++ b/app/util/map.js
@@ -24,7 +24,7 @@ module.exports = {
 
 	/**
 	 * Gets the surface distance between two Earth coordinates in meters
-	 * @function getDistance
+	 * @function
 	 * @param {number} lat1 The latitude of the first point
 	 * @param {number} lon1 The longitude of the first point
 	 * @param {number} lat2 The latitude of the second point
@@ -48,7 +48,7 @@ module.exports = {
 
 	/**
 	 * Gets the coordinates of the midpoint between two coordinates
-	 * @function getMidpointCoords
+	 * @function
 	 * @param {number} lat1 The latitude of the first point
 	 * @param {number} lon1 The longitude of the first point
 	 * @param {number} lat2 The latitude of the second point

--- a/app/util/shuttle.js
+++ b/app/util/shuttle.js
@@ -6,7 +6,7 @@ module.exports = {
 
 	/**
 	 * Gets the minutes of "estimated time of arrival" from an amount of seconds
-	 * @function getMinutesETA
+	 * @function
 	 * @param {number} secondToArrival The number of seconds until arrival
 	 * @returns {string} A user-friendly respresentation of the number of minutes
 	 */

--- a/app/util/shuttle.js
+++ b/app/util/shuttle.js
@@ -1,5 +1,10 @@
 module.exports = {
 
+	/**
+	 * Gets the minutes of "estimated time of arrival" from an amount of seconds
+	 * @param {number} secondToArrival - The number of seconds until arrival
+	 * @returns {string} A user-friendly respresentation of the number of minutes
+	 */
 	getMinutesETA(secondsToArrival) {
 		if (secondsToArrival < 1) {
 			return ('Arrived');

--- a/app/util/shuttle.js
+++ b/app/util/shuttle.js
@@ -1,8 +1,13 @@
+/**
+ * A module containing shuttle-related helper functions
+ * @module util/shuttle
+ */
 module.exports = {
 
 	/**
 	 * Gets the minutes of "estimated time of arrival" from an amount of seconds
-	 * @param {number} secondToArrival - The number of seconds until arrival
+	 * @function getMinutesETA
+	 * @param {number} secondToArrival The number of seconds until arrival
 	 * @returns {string} A user-friendly respresentation of the number of minutes
 	 */
 	getMinutesETA(secondsToArrival) {

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,28 @@
+{
+  "tags": {
+    "allowUnknownTags": true
+  },
+  "plugins": ["plugins/markdown"],
+  "templates": {
+    "logoFile": "",
+    "cleverLinks": false,
+    "monospaceLinks": false,
+    "dateFormat": "ddd MMM Do YYYY",
+    "outputSourceFiles": true,
+    "outputSourcePath": true,
+    "systemName": "DocStrap",
+    "footer": "",
+    "copyright": "DocStrap Copyright © 2012-2015 The contributors to the JSDoc3 and DocStrap projects.",
+    "navType": "vertical",
+    "theme": "slate",
+    "linenums": true,
+    "collapseSymbols": false,
+    "inverseNav": true,
+    "protocol": "html://",
+    "methodHeadingReturns": false
+  },
+  "markdown": {
+    "parser": "gfm",
+    "hardwrap": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,17 +35,17 @@
     "redux-thunk": "2.1.0"
   },
   "devDependencies": {
-    "babel-eslint": "^6.1.2",
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.1",
+    "jest": "18.1.0",
+    "react-test-renderer": "15.4.2",
+    "babel-eslint": "^6.1.2",
     "eslint": "^3.2.2",
     "eslint-config-airbnb": "^10.0.0",
-    "eslint-plugin-flowtype": "^2.30.0",
+    "eslint-plugin-flowtype": "^2.4.1",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
-    "eslint-plugin-react": "^6.0.0",
-    "jest": "18.1.0",
-    "react-test-renderer": "15.4.2"
+    "eslint-plugin-react": "^6.0.0"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "insert-staging-values": "node scripts/replace_all.js staging",
     "insert-placeholder-values": "node scripts/replace_all.js placeholder",
     "apply-ga-bridge-fix": "node scripts/apply_google_analytics_bridge_fix.js",
-	"generate-docs": "./node_modules/.bin/jsdoc -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -R Readme.md -r ./app"
+    "generate-docs": "./node_modules/.bin/jsdoc -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -R Readme.md -r ./app"
   },
   "dependencies": {
     "dateformat": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   },
   "jest": {
     "preset": "react-native"
+  },
+  "script": {
+    "generate-docs": "./node_modules/.bin/jsdoc -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -R Readme.md -r ./app"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "dateformat": "1.0.12",
     "html-entities": "1.2.0",
+    "jsdoc": "^3.4.3",
     "moment": "2.15.2",
     "react": "15.4.2",
     "react-native": "0.39.0",

--- a/package.json
+++ b/package.json
@@ -35,17 +35,17 @@
     "redux-thunk": "2.1.0"
   },
   "devDependencies": {
+    "babel-eslint": "^6.1.2",
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.1",
-    "jest": "18.1.0",
-    "react-test-renderer": "15.4.2",
-    "babel-eslint": "^6.1.2",
     "eslint": "^3.2.2",
     "eslint-config-airbnb": "^10.0.0",
-    "eslint-plugin-flowtype": "^2.4.1",
+    "eslint-plugin-flowtype": "^2.30.0",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
-    "eslint-plugin-react": "^6.0.0"
+    "eslint-plugin-react": "^6.0.0",
+    "jest": "18.1.0",
+    "react-test-renderer": "15.4.2"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "insert-production-values": "node scripts/replace_all.js production",
     "insert-staging-values": "node scripts/replace_all.js staging",
     "insert-placeholder-values": "node scripts/replace_all.js placeholder",
-    "apply-ga-bridge-fix": "node scripts/apply_google_analytics_bridge_fix.js"
+    "apply-ga-bridge-fix": "node scripts/apply_google_analytics_bridge_fix.js",
+	"generate-docs": "./node_modules/.bin/jsdoc -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -R Readme.md -r ./app"
   },
   "dependencies": {
     "dateformat": "1.0.12",
@@ -50,8 +51,5 @@
   },
   "jest": {
     "preset": "react-native"
-  },
-  "script": {
-    "generate-docs": "./node_modules/.bin/jsdoc -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -R Readme.md -r ./app"
   }
 }


### PR DESCRIPTION
This PR does the following:
- adds JSDoc to the project's npm packages
- modifies the eslint configuration to validate JSDoc blocks
- modifies the eslint configuration to override the airbnb configuraton's no-tabs rule
- adds a "npm run generate-docs" script for generation of the docs
- adds a JSDoc configuration that utilizes the DocStrap "slate" theme (chosen because it includes a quick-search and is darker in color)
- adds JSDoc comments to all the module functions in the app/util directory
- adds a few @todo tags to certain functions in the util modules which were deemed "might need improvement" by myself

Notes:
- The JSDoc generation script currently throws errors for files not yet documented. These errors can be safely ignored as the JSDocs will still be generated properly.