### PR TITLE
Bump minSdkVersion to 18 for dependency flutter_secure_storage

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         applicationId "edu.ucsd.campusmobile"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
## Summary
minSdkVersion 18 is required for dependency flutter_secure_storage

## Changelog
[Android] [Fix] - Bump minSdkVersion to 18 for dependency flutter_secure_storage

## Test Plan
Android CI/CD pipeline builds successfully

