### PR TITLE
Clear qr text on dispose

### DIFF
--- a/lib/core/data_providers/barcode_data_provider.dart
+++ b/lib/core/data_providers/barcode_data_provider.dart
@@ -85,6 +85,10 @@ class BarcodeDataProvider extends ChangeNotifier {
     _controller.dispose();
   }
 
+  clearQrText() {
+    _qrText = '';
+  }
+
   ///SIMPLE GETTERS
   bool get isLoading => _isLoading;
   String get error => _error;

--- a/lib/ui/views/scanner/scanner_view.dart
+++ b/lib/ui/views/scanner/scanner_view.dart
@@ -90,6 +90,7 @@ class _QRViewExampleState extends State<ScannerView> {
   @override
   void dispose() {
     _barcodeDataProvider.disposeController();
+    _barcodeDataProvider.clearQrText();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
https://github.com/UCSD/campus-mobile/issues/682


## Changelog
[General] [Fix] - Clear scanned qr text when leaving scan view


## Test Plan
Enter scan view > scan code > see scanned code above submit button
Exit scan view > enter scan view > don't see previously scanned code above submit button
