### PR TITLE
address bug where student card would display for non-students as well

### DIFF
--- a/lib/core/data_providers/user_data_provider.dart
+++ b/lib/core/data_providers/user_data_provider.dart
@@ -82,7 +82,11 @@ class UserDataProvider extends ChangeNotifier {
   List<String> _notificationsSettings;
 
   activateStudentCards() {
-    _cardOrder.insertAll(0, _studentCards.toList());
+    int index = _cardOrder.indexOf('MyStudentChart');
+    if (index == -1) {
+      index = 0;
+    }
+    _cardOrder.insertAll(index, _studentCards.toList());
   }
 
   deactivateStudentCards() {

--- a/lib/core/data_providers/user_data_provider.dart
+++ b/lib/core/data_providers/user_data_provider.dart
@@ -34,9 +34,8 @@ class UserDataProvider extends ChangeNotifier {
       'special_events': true,
       'weather': true,
       'dining': true,
-      'schedule': true,
-      'finals': true,
-      'schedule': true,
+      'finals': false,
+      'schedule': false,
       'MyStudentChart': true
     };
     _cardOrder = [
@@ -49,19 +48,15 @@ class UserDataProvider extends ChangeNotifier {
 //      'weather',
 //      'special_events',
       'MyStudentChart',
-//      'finals',
-//      'schedule',
     ];
+
+    _studentCards = ['finals', 'schedule'];
     _notificationsSettingsStates = {
       'campusAnnouncements': true,
       'freeFood': true,
       'shuttle': true
     };
-    _notificationsSettings = [
-      'campusAnnouncements',
-      'freeFood',
-      'shuttle'
-    ];
+    _notificationsSettings = ['campusAnnouncements', 'freeFood', 'shuttle'];
   }
 
   ///STATES
@@ -83,7 +78,18 @@ class UserDataProvider extends ChangeNotifier {
   Map<String, bool> _notificationsSettingsStates;
 
   List<String> _cardOrder;
+  List<String> _studentCards;
   List<String> _notificationsSettings;
+
+  activateStudentCards() {
+    _cardOrder.insertAll(0, _studentCards.toList());
+  }
+
+  deactivateStudentCards() {
+    for (String card in _studentCards) {
+      _cardOrder.remove(card);
+    }
+  }
 
   ///Update the authentication model saved in state and save the model in persistent storage
   Future updateAuthenticationModel(AuthenticationModel model) async {
@@ -193,6 +199,9 @@ class UserDataProvider extends ChangeNotifier {
       notifyListeners();
       if (await silentLogin()) {
         await getUserProfile();
+        if (_userProfileModel.classifications.student) {
+          activateStudentCards();
+        }
         returnVal = true;
       }
       _isLoading = false;
@@ -232,6 +241,7 @@ class UserDataProvider extends ChangeNotifier {
     deleteUsernameFromDevice();
     var box = await Hive.openBox<AuthenticationModel>('AuthenticationModel');
     await box.clear();
+    //deactivateStudentCards();
     print('logged out');
     _isLoading = false;
     notifyListeners();
@@ -357,6 +367,7 @@ class UserDataProvider extends ChangeNotifier {
   DateTime get lastUpdated => _lastUpdated;
   Map<String, bool> get cardStates => _cardStates;
   List<String> get cardOrder => _cardOrder;
-  Map<String, bool> get notificationsSettingsStates => _notificationsSettingsStates;
+  Map<String, bool> get notificationsSettingsStates =>
+      _notificationsSettingsStates;
   List<String> get notificationsSettings => _notificationsSettings;
 }

--- a/lib/core/data_providers/user_data_provider.dart
+++ b/lib/core/data_providers/user_data_provider.dart
@@ -241,7 +241,7 @@ class UserDataProvider extends ChangeNotifier {
     deleteUsernameFromDevice();
     var box = await Hive.openBox<AuthenticationModel>('AuthenticationModel');
     await box.clear();
-    //deactivateStudentCards();
+    deactivateStudentCards();
     print('logged out');
     _isLoading = false;
     notifyListeners();

--- a/lib/ui/views/home/home.dart
+++ b/lib/ui/views/home/home.dart
@@ -50,7 +50,7 @@ class _HomeState extends State<Home> {
   List<Widget> getOrderedCardsList(List<String> order) {
     List<Widget> orderedCards = List<Widget>();
 
-    orderedCards.add(ScannerCard()); // not hideable and not reorderable
+    orderedCards.insert(0, ScannerCard());
 
     for (String card in order) {
       switch (card) {

--- a/lib/ui/views/home/home.dart
+++ b/lib/ui/views/home/home.dart
@@ -31,8 +31,10 @@ class _HomeState extends State<Home> {
   }
 
   List<Widget> createList(BuildContext context) {
-    List<Widget> orderedCards = getOrderedCardsList(Provider.of<UserDataProvider>(context).cardOrder);
-    List<Widget> noticesCards = getNoticesCardsList(Provider.of<NoticesDataProvider>(context).noticesModel);
+    List<Widget> orderedCards =
+        getOrderedCardsList(Provider.of<UserDataProvider>(context).cardOrder);
+    List<Widget> noticesCards = getNoticesCardsList(
+        Provider.of<NoticesDataProvider>(context).noticesModel);
 
     return noticesCards + orderedCards;
   }
@@ -79,12 +81,12 @@ class _HomeState extends State<Home> {
         case 'MyStudentChart':
           orderedCards.add(MyChartCard());
           break;
-//        case 'finals':
-//          orderedCards.add(FinalsCard());
-//          break;
-//        case 'schedule':
-//          orderedCards.add(ClassScheduleCard());
-//          break;
+        case 'finals':
+          orderedCards.add(FinalsCard());
+          break;
+        case 'schedule':
+          orderedCards.add(ClassScheduleCard());
+          break;
       }
     }
     return orderedCards;


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
address bug where student card would display for non-students as well
## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[CATEGORY] [TYPE] - Message

1. [General] [Fix] - Prevent schedule and final cards from showing up on non-student logins
## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Need a student to help verify this fix
Already verified that cards do not show up on non-student logins

