### PR TITLE
Feature/#688 use v2 of the barcode post api

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -9,7 +9,8 @@ class RoutePaths {
   static const String Notifications = 'notifications';
   static const String Profile = 'profile';
   static const String CardsView = 'profile/cards_view';
-  static const String NotificationsSettingsView = 'notifications/notifications_settings';
+  static const String NotificationsSettingsView =
+      'notifications/notifications_settings';
 
   static const String NewsViewAll = 'news/newslist';
   static const String BaseLineView = 'baseline/baselineview';
@@ -43,6 +44,11 @@ class ButtonText {
   static const ScanNow = 'Scan Now';
   static const SignInFull = 'Sign In to Scan Your COVID-19 Test Kit.';
   static const SignIn = 'Sign In';
+}
+
+class ErrorConstants {
+  static const authorizedPostErrors = 'Failed to upload data: ';
+  static const invalidBearerToken = 'Invalid bearer token';
 }
 
 class Plugins {

--- a/lib/core/data_providers/availability_data_provider.dart
+++ b/lib/core/data_providers/availability_data_provider.dart
@@ -1,3 +1,4 @@
+import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
 import 'package:campus_mobile_experimental/core/data_providers/user_data_provider.dart';
 import 'package:campus_mobile_experimental/core/models/availability_model.dart';
 import 'package:flutter/material.dart';
@@ -53,7 +54,11 @@ class AvailabilityDataProvider extends ChangeNotifier {
           _userDataProvider.userProfileModel.selectedOccuspaceLocations);
       _lastUpdated = DateTime.now();
     } else {
-      ///TODO: determine what error to show to the user
+      if (_error.contains(ErrorConstants.invalidBearerToken)) {
+        if (await _availabilityService.getNewToken()) {
+          await fetchAvailability();
+        }
+      }
       _error = _availabilityService.error;
     }
     _isLoading = false;

--- a/lib/core/data_providers/barcode_data_provider.dart
+++ b/lib/core/data_providers/barcode_data_provider.dart
@@ -11,9 +11,7 @@ class BarcodeDataProvider extends ChangeNotifier {
 
     ///INITIALIZE SERVICES
     _barcodeService = BarcodeService();
-    _cameraState = Plugins.FrontCamera;
-    _submitState = ButtonText.SubmitButtonActive;
-    _qrText = "";
+    initState();
   }
 
   ///STATES
@@ -33,7 +31,14 @@ class BarcodeDataProvider extends ChangeNotifier {
   ///SERVICES
   BarcodeService _barcodeService;
 
+  void initState() {
+    _cameraState = Plugins.FrontCamera;
+    _submitState = ButtonText.SubmitButtonActive;
+    _qrText = "";
+  }
+
   void onQRViewCreated(QRViewController controller) {
+    initState();
     this._controller = controller;
     controller.scannedDataStream.listen((scanData) {
       if (_qrText != scanData) {
@@ -43,6 +48,7 @@ class BarcodeDataProvider extends ChangeNotifier {
         notifyListeners();
       }
     });
+    notifyListeners();
   }
 
   Future<Map<String, dynamic>> createUserData() async {

--- a/lib/core/data_providers/barcode_data_provider.dart
+++ b/lib/core/data_providers/barcode_data_provider.dart
@@ -73,7 +73,11 @@ class BarcodeDataProvider extends ChangeNotifier {
       if (results) {
         _submitState = ButtonText.SubmitButtonReceived;
       } else {
-        await _userDataProvider.refreshToken();
+        if (_barcodeService.error.contains(ErrorConstants.invalidBearerToken)) {
+          await _userDataProvider.refreshToken();
+        } else {
+          _error = _barcodeService.error;
+        }
         _submitState = ButtonText.SubmitButtonTryAgain;
       }
       _isLoading = false;

--- a/lib/core/services/barcode_service.dart
+++ b/lib/core/services/barcode_service.dart
@@ -6,7 +6,7 @@ class BarcodeService {
   String _error;
 
   final NetworkHelper _networkHelper = NetworkHelper();
-  final String _endpoint = 'https://api.ucsd.edu:8243/scandata/1.0.0/scanData';
+  final String _endpoint = 'https://api.ucsd.edu:8243/scandata/2.0.0/scanData';
 
   Future<bool> uploadResults(
       Map<String, String> headers, Map<String, dynamic> body) async {

--- a/lib/core/services/networking.dart
+++ b/lib/core/services/networking.dart
@@ -51,8 +51,6 @@ class NetworkHelper {
     dio.options.receiveTimeout = 20000;
     dio.options.headers = headers;
     final _response = await dio.post(url, data: body);
-    print('response is:');
-    print(_response.toString());
     if (_response.statusCode == 200 || _response.statusCode == 201) {
       // If server returns an OK response, return the body
       return _response.data;

--- a/lib/core/services/networking.dart
+++ b/lib/core/services/networking.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:dio/dio.dart';
+import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
 
 class NetworkHelper {
   ///TODO: inside each service that file place a switch statement to handle all
@@ -49,23 +50,27 @@ class NetworkHelper {
     dio.options.connectTimeout = 20000;
     dio.options.receiveTimeout = 20000;
     dio.options.headers = headers;
-    try {
-      final _response = await dio.post(url, data: body);
-      if (_response.statusCode == 200 || _response.statusCode == 201) {
-        // If server returns an OK response, return the body
-        return _response.data;
-      } else {
-        print('error thrown in authorizedPost');
-
-        ///TODO: log this as a bug because the response was bad
-        // If that response was not OK, throw an error.
-        throw Exception('Failed to upload data: ' + _response.data);
-      }
-    } on TimeoutException catch (e) {
-      // Display an alert, no internet
-    } catch (err) {
-      print(err);
-      return null;
+    final _response = await dio.post(url, data: body);
+    print('response is:');
+    print(_response.toString());
+    if (_response.statusCode == 200 || _response.statusCode == 201) {
+      // If server returns an OK response, return the body
+      return _response.data;
+    } else if (_response.statusCode == 400) {
+      // If that response was not OK, throw an error.
+      String message = _response.data['message'] ?? '';
+      throw Exception(ErrorConstants.authorizedPostErrors + message);
+    } else if (_response.statusCode == 401) {
+      throw Exception(ErrorConstants.authorizedPostErrors +
+          ErrorConstants.invalidBearerToken);
+    } else if (_response.statusCode == 404) {
+      String message = _response.data['message'] ?? '';
+      throw Exception(ErrorConstants.authorizedPostErrors + message);
+    } else if (_response.statusCode == 500) {
+      String message = _response.data['message'] ?? '';
+      throw Exception(ErrorConstants.authorizedPostErrors + message);
+    } else {
+      throw Exception(ErrorConstants.authorizedPostErrors + 'unknown error');
     }
   }
 

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -9,12 +9,17 @@ class NotificationService {
   String _error;
 
   Future<bool> postPushToken(Map<String, String> headers, body) async {
-    String response = await _networkHelper.authorizedPost(
-        _endpoint + '/register', headers, body);
-    if (response == 'Success') {
-      return true;
-    } else {
-      _error = response;
+    try {
+      String response = await _networkHelper.authorizedPost(
+          _endpoint + '/register', headers, body);
+      if (response == 'Success') {
+        return true;
+      } else {
+        _error = response;
+        return false;
+      }
+    } catch (e) {
+      _error = e.toString();
       return false;
     }
   }
@@ -22,12 +27,17 @@ class NotificationService {
   Future<bool> deletePushToken(
       Map<String, String> headers, String token) async {
     token = Uri.encodeComponent(token);
-    String response = await _networkHelper.authorizedDelete(
-        _endpoint + '/token/' + token, headers);
-    if (response == 'Success') {
-      return true;
-    } else {
-      _error = response;
+    try {
+      String response = await _networkHelper.authorizedDelete(
+          _endpoint + '/token/' + token, headers);
+      if (response == 'Success') {
+        return true;
+      } else {
+        _error = response;
+        return false;
+      }
+    } catch (e) {
+      _error = e.toString();
       return false;
     }
   }

--- a/lib/ui/views/scanner/scanner_view.dart
+++ b/lib/ui/views/scanner/scanner_view.dart
@@ -1,3 +1,4 @@
+import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
 import 'package:campus_mobile_experimental/core/constants/scanner_constants.dart';
 import 'package:campus_mobile_experimental/core/data_providers/barcode_data_provider.dart';
 import 'package:campus_mobile_experimental/ui/reusable_widgets/container_view.dart';
@@ -67,7 +68,10 @@ class _QRViewExampleState extends State<ScannerView> {
                           child: FlatButton(
                             disabledTextColor: Colors.black,
                             disabledColor: Color.fromRGBO(218, 218, 218, 1.0),
-                            onPressed: _barcodeDataProvider.qrText.isNotEmpty
+                            onPressed: _barcodeDataProvider.qrText.isNotEmpty &&
+                                    !_barcodeDataProvider.isLoading &&
+                                    _barcodeDataProvider.submitState !=
+                                        ButtonText.SubmitButtonReceived
                                 ? () => _barcodeDataProvider.submitBarcode()
                                 : null,
                             child: Text(_barcodeDataProvider.submitState,


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Handle errors returned by v2 of the  ScanDataAPI - 2.0.0
Update other upload methods in the app that use this service
Make sure the received button is not active

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->

   1. [General] [Add] - Add error handling in authorizedPost method inside network service file
   2. [General] [Change] - update other methods that used this authorizedPost
   3. [General] [Change] - update the submit button to be inactive when the upload was complete
   4. [General] [Change] - make sure that the scanners states are reset every time the view is created 
   4. [General] [Change] - update the barcode scanner service to point to v2 api


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Test with malformed data - Passed on iOS and android
Test with expected data - Passed on iOS and android 
Scan a barcode and leave view -> come back to scan view -> states are reset - Passed on iOS and android 
Scan a barcode and submit -> make sure received button is not tappable - Passed on iOS and android 
