### PR TITLE
Fix text overflow in dining detailed view on small screens

### DIFF
--- a/lib/ui/views/dining/dining_menu_list.dart
+++ b/lib/ui/views/dining/dining_menu_list.dart
@@ -153,46 +153,43 @@ class _DiningMenuListState extends State<DiningMenuList> {
   }
 
   Widget buildMealButtons(BuildContext context) {
-    return Container(
-      width: MediaQuery.of(context).size.width * .90,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: <Widget>[
-          LabeledRadio(
-            title: 'Breakfast',
-            value: Meal.breakfast,
-            groupValue: Provider.of<DiningDataProvider>(context).mealTime,
-            onChanged: (Meal value) {
-              setState(() {
-                Provider.of<DiningDataProvider>(context, listen: false)
-                    .mealTime = value;
-              });
-            },
-          ),
-          LabeledRadio(
-            title: 'Lunch',
-            value: Meal.lunch,
-            groupValue: Provider.of<DiningDataProvider>(context).mealTime,
-            onChanged: (Meal value) {
-              setState(() {
-                Provider.of<DiningDataProvider>(context, listen: false)
-                    .mealTime = value;
-              });
-            },
-          ),
-          LabeledRadio(
-            title: 'Dinner',
-            value: Meal.dinner,
-            groupValue: Provider.of<DiningDataProvider>(context).mealTime,
-            onChanged: (Meal value) {
-              setState(() {
-                Provider.of<DiningDataProvider>(context, listen: false)
-                    .mealTime = value;
-              });
-            },
-          ),
-        ],
-      ),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: <Widget>[
+        LabeledRadio(
+          title: 'Breakfast',
+          value: Meal.breakfast,
+          groupValue: Provider.of<DiningDataProvider>(context).mealTime,
+          onChanged: (Meal value) {
+            setState(() {
+              Provider.of<DiningDataProvider>(context, listen: false).mealTime =
+                  value;
+            });
+          },
+        ),
+        LabeledRadio(
+          title: 'Lunch',
+          value: Meal.lunch,
+          groupValue: Provider.of<DiningDataProvider>(context).mealTime,
+          onChanged: (Meal value) {
+            setState(() {
+              Provider.of<DiningDataProvider>(context, listen: false).mealTime =
+                  value;
+            });
+          },
+        ),
+        LabeledRadio(
+          title: 'Dinner',
+          value: Meal.dinner,
+          groupValue: Provider.of<DiningDataProvider>(context).mealTime,
+          onChanged: (Meal value) {
+            setState(() {
+              Provider.of<DiningDataProvider>(context, listen: false).mealTime =
+                  value;
+            });
+          },
+        ),
+      ],
     );
   }
 }
@@ -209,22 +206,20 @@ class LabeledRadio extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
+    return Container(
       child: Row(
         children: <Widget>[
           Radio(
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
             value: value,
             groupValue: groupValue,
             onChanged: onChanged,
             activeColor: Theme.of(context).buttonColor,
           ),
-          Flexible(
-            child: Container(
-              child: Text(
-                title,
-                style: TextStyle(fontSize: 16),
-                overflow: TextOverflow.clip,
-              ),
+          Container(
+            child: Text(
+              title,
+              style: TextStyle(fontSize: 16),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
This will solve the issue of the text on the filtering radio buttons from overflowing onto another line when displayed on a small screen by giving more room to work with.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Prevent text from overflowing onto the next line in dining on the radio filtering buttons. #727 


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Tested only on Android devices
**Pixel 3a Emulator (1080x2220) [5.6in screen]**
![Screenshot_1591305894](https://user-images.githubusercontent.com/43897566/83812088-c67ec980-a66f-11ea-8069-ac4dc8b562e5.png)
**Nexus One Emulator (480*800) [3.7in screen]**
![Screenshot_1591306002](https://user-images.githubusercontent.com/43897566/83812212-f928c200-a66f-11ea-9215-797f89ef5d35.png)

