### PR TITLE
Feature/remote control card states

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -78,6 +78,6 @@ class CardTitleConstants {
     'MyStudentChart': 'MyStudentChart',
     'finals': 'Finals',
     'schedule': 'Schedule',
-    'qr_scanner': 'QR Scanner'
+    'QRScanner': 'QR Scanner'
   };
 }

--- a/lib/core/data_providers/cards_data_provider.dart
+++ b/lib/core/data_providers/cards_data_provider.dart
@@ -1,9 +1,7 @@
-import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
-import 'package:campus_mobile_experimental/core/data_providers/user_data_provider.dart';
-import 'package:campus_mobile_experimental/core/services/barcode_service.dart';
+import 'package:campus_mobile_experimental/core/models/cards_model.dart';
+import 'package:campus_mobile_experimental/core/services/cards_service.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
-import 'package:qr_code_scanner/qr_code_scanner.dart';
 
 class CardsDataProvider extends ChangeNotifier {
   CardsDataProvider() {
@@ -41,8 +39,66 @@ class CardsDataProvider extends ChangeNotifier {
   List<String> _cardOrder;
   Map<String, bool> _cardStates;
   List<String> _studentCards;
+  Map<String, CardsModel> _availableCards;
 
-  ///SERVICES
+  ///Services
+  final CardsService _cardsService = CardsService();
+
+  void updateAvailableCards() async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    if (await _cardsService.fetchCards()) {
+      _availableCards = _cardsService.cardsModel;
+      _lastUpdated = DateTime.now();
+      if (_availableCards.isNotEmpty) {
+        // remove all inactive or non-existent cards from [_cardOrder]
+        var tempCardOrder = List.from(_cardOrder);
+        for (String card in tempCardOrder) {
+          // check to see if card no longer exists
+          if (_availableCards[card] == null) {
+            _cardOrder.remove(card);
+          }
+          // check to see if card is not active
+          else if (!_availableCards[card].cardActive) {
+            _cardOrder.remove(card);
+          }
+        }
+        // remove all inactive or non-existent cards from [_cardStates]
+        var tempCardStates = Map.from(_cardStates);
+        for (String card in tempCardStates.keys) {
+          // check to see if card no longer exists
+          if (_availableCards[card] == null) {
+            _cardStates.remove(card);
+          }
+          // check to see if card is not active
+          else if (!_availableCards[card].cardActive) {
+            _cardStates.remove(card);
+          }
+        }
+
+        // add new cards to the bottom of the list
+        for (String card in _availableCards.keys) {
+          if (_studentCards.contains(card)) continue;
+          if (!_cardOrder.contains(card) && _availableCards[card].cardActive) {
+            _cardOrder.insert(_cardOrder.length, card);
+          }
+          // keep all new cards deactivated by default
+          if (!_cardStates.containsKey(card)) {
+            _cardStates[card] = false;
+          }
+        }
+        updateCardOrder(_cardOrder);
+        updateCardStates(
+            _cardStates.keys.where((card) => _cardStates[card]).toList());
+      }
+    } else {
+      ///TODO: determine what error to show to the user
+      _error = _cardsService.error;
+    }
+    _isLoading = false;
+    notifyListeners();
+  }
 
   /// Update the [_cardOrder] stored in state
   /// overwrite the [_cardOrder] in persistent storage with the model passed in

--- a/lib/core/data_providers/provider_setup.dart
+++ b/lib/core/data_providers/provider_setup.dart
@@ -137,22 +137,26 @@ List<SingleChildWidget> dependentServices = [
             pushNotificationDataProvider;
         return _userDataProvider;
       }),
-  ChangeNotifierProxyProvider<UserDataProvider, CardsDataProvider>(create: (_) {
-    var cardsDataProvider = CardsDataProvider();
-    cardsDataProvider
-      ..loadCardOrder()
-      ..loadCardStates();
-
-    return cardsDataProvider;
-  }, update: (_, userDataProvider, cardsDataProvider) {
-    if (userDataProvider.isLoggedIn &&
-        (userDataProvider.userProfileModel.classifications?.student ?? false)) {
-      cardsDataProvider.activateStudentCards();
-    } else {
-      cardsDataProvider.deactivateStudentCards();
-    }
-    return cardsDataProvider;
-  }),
+  ChangeNotifierProxyProvider<UserDataProvider, CardsDataProvider>(
+      create: (_) {
+        var cardsDataProvider = CardsDataProvider();
+        cardsDataProvider
+          ..loadCardOrder()
+          ..loadCardStates()
+          ..updateAvailableCards();
+        return cardsDataProvider;
+      },
+      lazy: false,
+      update: (_, userDataProvider, cardsDataProvider) {
+        if (userDataProvider.isLoggedIn &&
+            (userDataProvider.userProfileModel.classifications?.student ??
+                false)) {
+          cardsDataProvider.activateStudentCards();
+        } else {
+          cardsDataProvider.deactivateStudentCards();
+        }
+        return cardsDataProvider;
+      }),
   ChangeNotifierProxyProvider<UserDataProvider, ClassScheduleDataProvider>(
       create: (_) {
     var classDataProvider = ClassScheduleDataProvider();

--- a/lib/core/models/cards_model.dart
+++ b/lib/core/models/cards_model.dart
@@ -1,0 +1,28 @@
+// To parse this JSON data, do
+//
+//     final cardsModel = cardsModelFromJson(jsonString);
+
+import 'dart:convert';
+
+Map<String, CardsModel> cardsModelFromJson(String str) =>
+    Map.from(json.decode(str))
+        .map((k, v) => MapEntry<String, CardsModel>(k, CardsModel.fromJson(v)));
+
+String cardsModelToJson(Map<String, CardsModel> data) => json.encode(
+    Map.from(data).map((k, v) => MapEntry<String, dynamic>(k, v.toJson())));
+
+class CardsModel {
+  CardsModel({
+    this.cardActive,
+  });
+
+  bool cardActive;
+
+  factory CardsModel.fromJson(Map<String, dynamic> json) => CardsModel(
+        cardActive: json["cardActive"] == null ? null : json["cardActive"],
+      );
+
+  Map<String, dynamic> toJson() => {
+        "cardActive": cardActive == null ? null : cardActive,
+      };
+}

--- a/lib/core/services/cards_service.dart
+++ b/lib/core/services/cards_service.dart
@@ -1,0 +1,37 @@
+import 'package:campus_mobile_experimental/core/models/cards_model.dart';
+import 'package:campus_mobile_experimental/core/services/networking.dart';
+
+class CardsService {
+  final String cardListEndpoint =
+      'https://ucsd-its-wts-dev.s3-us-west-1.amazonaws.com/replatform/v1/cardActivationControl.json';
+  bool _isLoading = false;
+  DateTime _lastUpdated;
+  String _error;
+
+  Map<String, CardsModel> _cardsModel;
+
+  final NetworkHelper _networkHelper = NetworkHelper();
+
+  Future<bool> fetchCards() async {
+    _error = null;
+    _isLoading = true;
+    try {
+      /// fetch data
+      String _response = await _networkHelper.fetchData(cardListEndpoint);
+
+      /// parse data
+      _cardsModel = cardsModelFromJson(_response);
+      _isLoading = false;
+      return true;
+    } catch (e) {
+      _error = e.toString();
+      _isLoading = false;
+      return false;
+    }
+  }
+
+  String get error => _error;
+  Map<String, CardsModel> get cardsModel => _cardsModel;
+  bool get isLoading => _isLoading;
+  DateTime get lastUpdated => _lastUpdated;
+}

--- a/lib/ui/cards/scanner/scanner_card.dart
+++ b/lib/ui/cards/scanner/scanner_card.dart
@@ -7,7 +7,7 @@ import 'package:campus_mobile_experimental/ui/reusable_widgets/card_container.da
 
 import 'package:provider/provider.dart';
 
-const String cardId = 'qr_scanner';
+const String cardId = 'QRScanner';
 
 class ScannerCard extends StatelessWidget {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
We have to do an app update every time we want to remove or add cards
This pr addresses that issue by creating a remote list of cards that controls the states of each card in the mobile app
## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->

[General][Add] - Add remote configuration for card states

## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

- [ ] Add a card to the json list and see if it shows up on the mobile client 

- [ ] Remove card from the json list and see if it is removed on the mobile client 
