### PR TITLE
address case where we have less than 3 events in the feed

### DIFF
--- a/lib/ui/views/events/events_list.dart
+++ b/lib/ui/views/events/events_list.dart
@@ -32,6 +32,11 @@ class EventsList extends StatelessWidget {
       size = listOfEvents.length;
     else
       size = listSize;
+
+    /// check to see if we have at least 3 events
+    if (size > listOfEvents.length) {
+      size = listOfEvents.length;
+    }
     for (int i = 0; i < size; i++) {
       final EventModel item = listOfEvents[i];
       final tile = buildEventTile(item, context);


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
When the events feed has less than 3 events the events card would error out.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[Change] [Fix] - Added logic to make sure all sizes of events list are handled


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

- [ ] Change the size of the events list and see if card functions as expected