### PR TITLE
Add learn more button to event detail

### DIFF
--- a/lib/ui/views/events/event_detail_view.dart
+++ b/lib/ui/views/events/event_detail_view.dart
@@ -64,11 +64,26 @@ class EventDetailView extends StatelessWidget {
           style: TextStyle(fontSize: 16),
         ),
       ),
-//      FlatButton(
-//          child: Text('Learn More'),
-//          onPressed: () {
-//            launch(data.url);
-//          })
+      data.url != null && data.url.isNotEmpty
+          ? Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: FlatButton(
+                  child: Text(
+                    'Learn More',
+                    style: TextStyle(
+                        fontSize: 16,
+                        color: Theme.of(context).textTheme.button.color),
+                  ),
+                  color: Theme.of(context).buttonColor,
+                  onPressed: () async {
+                    if (await canLaunch(data.url)) {
+                      await launch(data.url);
+                    } else {
+                      throw 'Could not launch ${data.url}';
+                    }
+                  }),
+            )
+          : Container(),
     ];
   }
 }

--- a/lib/ui/views/events/event_detail_view.dart
+++ b/lib/ui/views/events/event_detail_view.dart
@@ -76,10 +76,14 @@ class EventDetailView extends StatelessWidget {
                   ),
                   color: Theme.of(context).buttonColor,
                   onPressed: () async {
-                    if (await canLaunch(data.url)) {
-                      await launch(data.url);
-                    } else {
-                      throw 'Could not launch ${data.url}';
+                    try {
+                      if (await canLaunch(data.url)) {
+                        await launch(data.url);
+                      } else {
+                        throw 'Could not launch ${data.url}';
+                      }
+                    } catch (e) {
+                      print(e);
                     }
                   }),
             )


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Adds a 'Learn More' button to the event detail if a URL is provided. (#744) 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Add] - Add learn more button to event detail


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

- [x] Learn more button appears when URL field has content
- [x] Learn more button does not appear when URL field is null
- [x] Learn more button does not appear when URL field is an empty string
- [x] Error thrown and caught if URL is invalid
