### PR TITLE
Resolved Duplicate Classes Bug

### DIFF
--- a/lib/core/data_providers/class_schedule_data_provider.dart
+++ b/lib/core/data_providers/class_schedule_data_provider.dart
@@ -56,81 +56,83 @@ class ClassScheduleDataProvider extends ChangeNotifier {
   ClassScheduleService _classScheduleService;
 
   void fetchData() async {
-    _isLoading = true;
-    _error = null;
-    notifyListeners();
-    if (await _classScheduleService.fetchAcademicTerm() &&
-        _userDataProvider.isLoggedIn) {
-      _academicTermModel = _classScheduleService.academicTermModel;
-      final Map<String, String> headers = {
-        'Authorization':
-            'Bearer ${_userDataProvider?.authenticationModel?.accessToken}'
-      };
+    if (!_isLoading) {
+      _isLoading = true;
+      _error = null;
+      notifyListeners();
+      if (await _classScheduleService.fetchAcademicTerm() &&
+          _userDataProvider.isLoggedIn) {
+        _academicTermModel = _classScheduleService.academicTermModel;
+        final Map<String, String> headers = {
+          'Authorization':
+          'Bearer ${_userDataProvider?.authenticationModel?.accessToken}'
+        };
 
-      /// erase old model
-      _classScheduleModel = ClassScheduleModel();
+        /// erase old model
+        _classScheduleModel = ClassScheduleModel();
 
-      /// fetch grad courses
-      if (await _classScheduleService.fetchGRCourses(
-          headers, _academicTermModel.termCode)) {
-        _classScheduleModel = _classScheduleService.GRdata;
-      } else {
-        _error = _classScheduleService.error.toString();
-      }
-
-      /// fetch undergrad courses
-      if (await _classScheduleService.fetchUNCourses(
-          headers, _academicTermModel.termCode)) {
-        if (_classScheduleModel.data != null) {
-          _classScheduleModel.data.addAll(_classScheduleService.UNdata.data);
+        /// fetch grad courses
+        if (await _classScheduleService.fetchGRCourses(
+            headers, _academicTermModel.termCode)) {
+          _classScheduleModel = _classScheduleService.GRdata;
         } else {
-          _classScheduleModel = _classScheduleService.UNdata;
+          _error = _classScheduleService.error.toString();
         }
-        _error = null;
+
+        /// fetch undergrad courses
+        if (await _classScheduleService.fetchUNCourses(
+            headers, _academicTermModel.termCode)) {
+          if (_classScheduleModel.data != null) {
+            _classScheduleModel.data.addAll(_classScheduleService.UNdata.data);
+          } else {
+            _classScheduleModel = _classScheduleService.UNdata;
+          }
+          _error = null;
+        } else {
+          _error = _classScheduleService.error.toString();
+          _isLoading = false;
+          notifyListeners();
+
+          /// short circuit
+          return;
+        }
+
+        /// remove all old classes
+        _enrolledClasses = {
+          'MO': List<SectionData>(),
+          'TU': List<SectionData>(),
+          'WE': List<SectionData>(),
+          'TH': List<SectionData>(),
+          'FR': List<SectionData>(),
+          'SA': List<SectionData>(),
+          'SU': List<SectionData>(),
+          'OTHER': List<SectionData>(),
+        };
+
+        _finals = {
+          'MO': List<SectionData>(),
+          'TU': List<SectionData>(),
+          'WE': List<SectionData>(),
+          'TH': List<SectionData>(),
+          'FR': List<SectionData>(),
+          'SA': List<SectionData>(),
+          'SU': List<SectionData>(),
+          'OTHER': List<SectionData>(),
+        };
+        try {
+          _createMapOfClasses();
+        } catch (e) {
+          _error = e.toString();
+        }
+
+        _lastUpdated = DateTime.now();
       } else {
-        _error = _classScheduleService.error.toString();
-        _isLoading = false;
-        notifyListeners();
-
-        /// short circuit
-        return;
+        ///TODO: determine what error to show to the user
+        _error = _classScheduleService.error;
       }
-
-      /// remove all old classes
-      _enrolledClasses = {
-        'MO': List<SectionData>(),
-        'TU': List<SectionData>(),
-        'WE': List<SectionData>(),
-        'TH': List<SectionData>(),
-        'FR': List<SectionData>(),
-        'SA': List<SectionData>(),
-        'SU': List<SectionData>(),
-        'OTHER': List<SectionData>(),
-      };
-
-      _finals = {
-        'MO': List<SectionData>(),
-        'TU': List<SectionData>(),
-        'WE': List<SectionData>(),
-        'TH': List<SectionData>(),
-        'FR': List<SectionData>(),
-        'SA': List<SectionData>(),
-        'SU': List<SectionData>(),
-        'OTHER': List<SectionData>(),
-      };
-      try {
-        _createMapOfClasses();
-      } catch (e) {
-        _error = e.toString();
-      }
-
-      _lastUpdated = DateTime.now();
-    } else {
-      ///TODO: determine what error to show to the user
-      _error = _classScheduleService.error;
+      _isLoading = false;
+      notifyListeners();
     }
-    _isLoading = false;
-    notifyListeners();
   }
 
   void _createMapOfClasses() {

--- a/lib/ui/cards/class_schedule/class_schedule_card.dart
+++ b/lib/ui/cards/class_schedule/class_schedule_card.dart
@@ -32,9 +32,14 @@ class ClassScheduleCard extends StatelessWidget {
       active: Provider.of<CardsDataProvider>(context).cardStates[cardId],
       hide: () => Provider.of<CardsDataProvider>(context, listen: false)
           .toggleCard(cardId),
-      reload: () =>
-          Provider.of<ClassScheduleDataProvider>(context, listen: false)
-              .fetchData(),
+      reload: () {
+        if (Provider.of<ClassScheduleDataProvider>(context, listen: false).isLoading){
+          return null;
+        }
+        else{
+          Provider.of<ClassScheduleDataProvider>(context, listen: false).fetchData();
+        }
+      },
       isLoading: Provider.of<ClassScheduleDataProvider>(context).isLoading,
       titleText: CardTitleConstants.titleMap[cardId],
       errorText: Provider.of<ClassScheduleDataProvider>(context).error,

--- a/lib/ui/cards/finals/finals_card.dart
+++ b/lib/ui/cards/finals/finals_card.dart
@@ -17,9 +17,14 @@ class FinalsCard extends StatelessWidget {
       active: Provider.of<CardsDataProvider>(context).cardStates[cardId],
       hide: () => Provider.of<CardsDataProvider>(context, listen: false)
           .toggleCard(cardId),
-      reload: () =>
-          Provider.of<ClassScheduleDataProvider>(context, listen: false)
-              .fetchData(),
+      reload: () {
+        if (Provider.of<ClassScheduleDataProvider>(context, listen: false).isLoading){
+          return null;
+        }
+        else{
+          Provider.of<ClassScheduleDataProvider>(context, listen: false).fetchData();
+        }
+      },
       isLoading: Provider.of<ClassScheduleDataProvider>(context).isLoading,
       titleText: CardTitleConstants.titleMap[cardId],
       errorText: Provider.of<ClassScheduleDataProvider>(context).error,


### PR DESCRIPTION
## Summary
 Finals and Classes card displayed duplicates of each class if reloaded repeatedly.

## Changelog
[General] [Fix] - Prevented multiple asynchronous calls by adding If Statements. In class_schedule_data_provider, fetchData will only run if not loading and in finals_card and class_schedule_card, reload will return null if loading. 




## Test Plan
Tested on Samsung S7

