### PR TITLE
Implement Navigation Titles#799

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,4 +1,5 @@
 import 'package:campus_mobile_experimental/core/models/parking_model.dart';
+import 'package:campus_mobile_experimental/ui/views/news/news_detail_view.dart';
 
 class RoutePaths {
   static const String Home = '/';
@@ -37,6 +38,32 @@ class RoutePaths {
   static const String ScannerView = 'scanner/scanner_view';
 }
 
+class RouteTitles {
+  static const titleMap = {
+    'Maps': 'Maps',
+    'MapSearch': 'Maps',
+    'MapLocationList': 'Maps',
+    'Notifications': 'Notifications',
+    'Profile': 'Profile',
+    'profile/cards_view': 'Cards',
+    'notifications/notifications_settings': "Notification Settings",
+    'news/newslist': 'News',
+    'news/news_detail_view': 'News',
+    'events/eventslist': 'Events',
+    'events/event_detail_view': 'Events',
+    'class/classList': 'Class Schedule',
+    'availability/manage_locations_view': 'Manage Locations',
+    'parking/manage_parking_view': 'Parking',
+    'dining/dining_list_view': 'Dining',
+    'dining/dining_detail_view': 'Dining',
+    'dining/dining_nutrition_view': 'Dining',
+    'special_events/special_events_list_view': 'Special Events',
+    'special_events/special_events_filter_view': 'Special Events',
+    'special_events/special_events_detail_view': 'Special Events',
+    'scanner/scanner_view': 'Scanner',
+  };
+}
+
 class ButtonText {
   static const SubmitButtonActive = 'Submit';
   static const SubmitButtonInactive = 'Sending';
@@ -62,6 +89,13 @@ class NavigationConstants {
   static const MapTab = 1;
   static const NotificationsTab = 2;
   static const ProfileTab = 3;
+//  static const AvailabilityView = 4;
+//  static const ScheduleView = 5;
+//  static const DiningView = 6;
+//  static const EventsView = 7;
+//  static const NewsDetailView = 8;
+//  static const NotificationsView = 9;
+//  static const ParkingView = 10;
 }
 
 /// Maps Card IDs to Card titles

--- a/lib/core/navigation/bottom_tab_bar/bottom_navigation_bar_model.dart
+++ b/lib/core/navigation/bottom_tab_bar/bottom_navigation_bar_model.dart
@@ -1,4 +1,6 @@
+import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
 import 'package:campus_mobile_experimental/core/navigation/push_notification_wrapper.dart';
+import 'package:campus_mobile_experimental/core/navigation/top_navigation_bar/app_bar.dart';
 import 'package:campus_mobile_experimental/core/services/bottom_navigation_bar_service.dart';
 import 'package:campus_mobile_experimental/ui/views/home/home.dart';
 import 'package:campus_mobile_experimental/ui/views/map/map.dart' as prefix0;
@@ -6,6 +8,7 @@ import 'package:campus_mobile_experimental/ui/views/notifications/notifications_
 import 'package:campus_mobile_experimental/ui/views/profile/profile.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:campus_mobile_experimental/core/navigation/top_navigation_bar/app_bar.dart';
 
 class BottomTabBar extends StatefulWidget {
   @override
@@ -25,23 +28,32 @@ class _BottomTabBarState extends State<BottomTabBar> {
     var provider = Provider.of<BottomNavigationBarProvider>(context);
     return Scaffold(
       appBar: PreferredSize(
-        preferredSize: Size.fromHeight(42),
-        child: AppBar(
-          primary: true,
-          centerTitle: true,
-          title: Image.asset(
-            'assets/images/UCSanDiegoLogo-nav.png',
-            fit: BoxFit.contain,
-            height: 28,
-          ),
-        ),
-      ),
+          preferredSize: Size.fromHeight(42),
+          child: Provider.of<CustomAppBar>(context).appBar),
       body: PushNotificationWrapper(child: currentTab[provider.currentIndex]),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
         currentIndex: provider.currentIndex,
         onTap: (index) {
           provider.currentIndex = index;
+          switch (index) {
+            case NavigationConstants.HomeTab:
+              Provider.of<CustomAppBar>(context, listen: false)
+                  .changeTitle(null);
+              break;
+            case NavigationConstants.MapTab:
+              Provider.of<CustomAppBar>(context, listen: false)
+                  .changeTitle("Maps");
+              break;
+            case NavigationConstants.NotificationsTab:
+              Provider.of<CustomAppBar>(context, listen: false)
+                  .changeTitle("Notifications");
+              break;
+            case NavigationConstants.ProfileTab:
+              Provider.of<CustomAppBar>(context, listen: false)
+                  .changeTitle("Profile");
+              break;
+          }
         },
         items: [
           BottomNavigationBarItem(

--- a/lib/core/navigation/router.dart
+++ b/lib/core/navigation/router.dart
@@ -4,6 +4,7 @@ import 'package:campus_mobile_experimental/core/models/dining_model.dart';
 import 'package:campus_mobile_experimental/core/models/events_model.dart';
 import 'package:campus_mobile_experimental/core/models/news_model.dart';
 import 'package:campus_mobile_experimental/core/navigation/bottom_tab_bar/bottom_navigation_bar_model.dart';
+import 'package:campus_mobile_experimental/core/navigation/top_navigation_bar/app_bar.dart';
 import 'package:campus_mobile_experimental/ui/cards/dining/dining_list.dart';
 import 'package:campus_mobile_experimental/ui/views/availability/manage_availability_view.dart';
 import 'package:campus_mobile_experimental/ui/views/baseline/baseline_view.dart';
@@ -34,6 +35,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 import 'bottom_tab_bar/bottom_navigation_bar_model.dart';
+import 'package:provider/provider.dart';
 
 class Router {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -64,9 +66,15 @@ class Router {
         return MaterialPageRoute(builder: (_) => Profile());
       case RoutePaths.NewsViewAll:
         NewsModel data = settings.arguments as NewsModel;
-        return MaterialPageRoute(builder: (_) => NewsList());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return NewsList();
+        });
       case RoutePaths.EventsViewAll:
-        return MaterialPageRoute(builder: (context) => EventsList());
+        return MaterialPageRoute(builder: (context) {
+          Provider.of<CustomAppBar>(context).changeTitle(settings.name);
+          return EventsList();
+        });
       case RoutePaths.BaseLineView:
         return MaterialPageRoute(builder: (_) => BaselineView());
       case RoutePaths.NewsDetailView:
@@ -77,14 +85,23 @@ class Router {
         EventModel data = settings.arguments as EventModel;
         return MaterialPageRoute(builder: (_) => EventDetailView(data: data));
       case RoutePaths.ManageAvailabilityView:
-        return MaterialPageRoute(builder: (_) => ManageAvailabilityView());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return ManageAvailabilityView();
+        });
       case RoutePaths.LinksViewAll:
         return MaterialPageRoute(builder: (_) => LinksList());
       case RoutePaths.DiningViewAll:
-        return MaterialPageRoute(builder: (_) => DiningList());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return DiningList();
+        });
       case RoutePaths.DiningDetailView:
         DiningModel data = settings.arguments as DiningModel;
-        return MaterialPageRoute(builder: (_) => DiningDetailView(data: data));
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return DiningDetailView(data: data);
+        });
       case RoutePaths.DiningNutritionView:
         Map<String, Object> arguments = settings.arguments;
         MenuItem data = arguments['data'] as MenuItem;
@@ -99,15 +116,30 @@ class Router {
       case RoutePaths.SurfView:
         return MaterialPageRoute(builder: (_) => SurfView());
       case RoutePaths.ManageParkingView:
-        return MaterialPageRoute(builder: (_) => ManageParkingView());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return ManageParkingView();
+        });
       case RoutePaths.CardsView:
-        return MaterialPageRoute(builder: (_) => CardsView());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return CardsView();
+        });
       case RoutePaths.NotificationsSettingsView:
-        return MaterialPageRoute(builder: (_) => NotificationsSettingsView());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return NotificationsSettingsView();
+        });
       case RoutePaths.ScannerView:
-        return MaterialPageRoute(builder: (_) => ScannerView());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return ScannerView();
+        });
       case RoutePaths.ClassScheduleViewAll:
-        return MaterialPageRoute(builder: (_) => ClassList());
+        return MaterialPageRoute(builder: (_) {
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          return ClassList();
+        });
     }
   }
 }

--- a/lib/core/navigation/top_navigation_bar/app_bar.dart
+++ b/lib/core/navigation/top_navigation_bar/app_bar.dart
@@ -1,6 +1,11 @@
+import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
 import 'package:flutter/material.dart';
 
 class CMAppBar extends StatelessWidget {
+  CMAppBar({
+    this.title,
+  });
+  String title;
   @override
   Widget build(BuildContext context) {
     return PreferredSize(
@@ -8,11 +13,13 @@ class CMAppBar extends StatelessWidget {
       child: AppBar(
         primary: true,
         centerTitle: true,
-        title: Image.asset(
-          'assets/images/UCSanDiegoLogo-nav.png',
-          fit: BoxFit.contain,
-          height: 28,
-        ),
+        title: title == null
+            ? Image.asset(
+                'assets/images/UCSanDiegoLogo-nav.png',
+                fit: BoxFit.contain,
+                height: 28,
+              )
+            : Text(title),
       ),
     );
   }
@@ -20,11 +27,18 @@ class CMAppBar extends StatelessWidget {
 
 class CustomAppBar extends ChangeNotifier {
   CMAppBar appBar;
+  String title;
   CustomAppBar() {
     makeAppBar();
   }
   makeAppBar() {
-    appBar = CMAppBar();
-    notifyListeners();
+    appBar = CMAppBar(
+      title: title,
+    );
+  }
+
+  changeTitle(String newTitle) {
+    title = RouteTitles.titleMap[newTitle];
+    makeAppBar();
   }
 }


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Implemented Navigation titles on Tab and Detailed views within the app. Added custom AppBar titles instead of having the default UCSD logo at the top.

## Changelog
<!--
   
-->
[GENERAL] [Add] - Added custom navigation titles to each detailed view and bottom tab view. Home screen still displays default logo. 


## Test Plan
<!--
    
--> 
![Screenshot_1594227394](https://user-images.githubusercontent.com/64249245/86954678-471b6480-c10b-11ea-8af6-0b0c06fe0334.png)
![Screenshot_1594227374](https://user-images.githubusercontent.com/64249245/86954689-4b478200-c10b-11ea-9eff-5e0349db2393.png)

- [x] All other views display their title in the navigation bar (i.e. 'News' for News List, News Detail, 'Notifications' for the notifications tab)

- [x]  The UC San Diego logo appears on the Home view only
