### PR TITLE
Fix text overflow on MyChart and Scanner cards

### DIFF
--- a/lib/ui/cards/my_chart/my_chart_card.dart
+++ b/lib/ui/cards/my_chart/my_chart_card.dart
@@ -1,9 +1,8 @@
 import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
 import 'package:campus_mobile_experimental/core/data_providers/cards_data_provider.dart';
+import 'package:campus_mobile_experimental/ui/reusable_widgets/card_container.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:campus_mobile_experimental/ui/reusable_widgets/card_container.dart';
-
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -44,9 +43,11 @@ class MyChartCard extends StatelessWidget {
               right: 10,
             ),
           ),
-          Text(
-            'Your secure online health connection.',
-            textAlign: TextAlign.left,
+          Flexible(
+            child: Text(
+              'Your secure online health connection.',
+              textAlign: TextAlign.left,
+            ),
           )
         ],
       ),
@@ -80,6 +81,3 @@ class MyChartCard extends StatelessWidget {
     }
   }
 }
-
-
-

--- a/lib/ui/cards/scanner/scanner_card.dart
+++ b/lib/ui/cards/scanner/scanner_card.dart
@@ -1,10 +1,9 @@
 import 'package:campus_mobile_experimental/core/constants/app_constants.dart';
 import 'package:campus_mobile_experimental/core/data_providers/user_data_provider.dart';
 import 'package:campus_mobile_experimental/core/services/bottom_navigation_bar_service.dart';
+import 'package:campus_mobile_experimental/ui/reusable_widgets/card_container.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:campus_mobile_experimental/ui/reusable_widgets/card_container.dart';
-
 import 'package:provider/provider.dart';
 
 const String cardId = 'QRScanner';
@@ -46,9 +45,11 @@ class ScannerCard extends StatelessWidget {
               right: 10,
             ),
           ),
-          Text(
-            getCardContentText(context),
-            textAlign: TextAlign.left,
+          Flexible(
+            child: Text(
+              getCardContentText(context),
+              textAlign: TextAlign.left,
+            ),
           )
         ],
       ),


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Prevents text from overflowing off-screen on the QR Scanner card and MyStudentChart card. #838 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Fix text overflow on QR Scanner card
[General] [Fix] - Fix text overflow on MyStudentChart card

## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
- [x] Text goes onto another line on small devices
- [x] Text still renders correctly on medium and large devices
