### PR TITLE
Fixed issue with receiving push notification on closed app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <application
+        android:name=".Application"
         android:label="UC San Diego"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Fixed issue where on receiving a push notification while the app was closed, a "UC San Diego has stopped" alert would pop up rather than a push notification

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[Android] [Fix] - Fixed Android manifest so that push notifications for closed apps would work properly.


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
To test this, have the app closed, then send out a push notification. Upon receiving the notification in the system tray and clicking on it, the user should be sent to the messages tab, where they can see the message.

