### PR TITLE
Add intent filter for deeplink

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,15 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="deeplink"
+                    android:path="/"
+                    android:host="ucsd.edu" />
+            </intent-filter>
         </activity>
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -632,13 +632,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  qr_code_scanner:
-    dependency: "direct main"
-    description:
-      name: qr_code_scanner
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.13"
   quiver:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
Android deeplink implementation

Also need to update scandit-web-sdk with implementation from /ivan-progress branch. To deeplink back into the app


## Changelog
[Android][Add] - Deeplink


## Test Plan
This is meant for the scanning feature, but can be tested by visiting this link "intent://ucsd.edu/#Intent;scheme=deeplink;package=edu.ucsd;end"

Needs to be through an <a/> link or some js action, not through browser url.
