### PR TITLE
campus info card bug fix

### DIFF
--- a/lib/ui/cards/campus_info/campus_info_card.dart
+++ b/lib/ui/cards/campus_info/campus_info_card.dart
@@ -17,8 +17,7 @@ class _CampusInfoCardState extends State<CampusInfoCard>
     with WidgetsBindingObserver {
   String cardId = "campus_info";
   WebViewController _webViewController;
-  String _url =
-      "https://mobile.ucsd.edu/replatform/v1/qa/webview/campus_info.html";
+  String url;
 
   @override
   void initState() {
@@ -39,7 +38,7 @@ class _CampusInfoCardState extends State<CampusInfoCard>
       hide: () => Provider.of<CardsDataProvider>(context, listen: false)
           .toggleCard(cardId),
       reload: () {
-        reloadWebViewWithTheme(context, _url, _webViewController);
+        reloadWebViewWithTheme(context, url, _webViewController);
       },
       isLoading: false,
       titleText: CardTitleConstants.titleMap[cardId],
@@ -53,14 +52,19 @@ class _CampusInfoCardState extends State<CampusInfoCard>
     super.didChangeDependencies();
   }
 
+  String fileURL =
+      "https://mobile.ucsd.edu/replatform/v1/qa/webview/campus_info.html";
+
   Widget buildCardContent(BuildContext context) {
-    reloadWebViewWithTheme(context, _url, _webViewController);
+    url = fileURL + "?";
+    reloadWebViewWithTheme(context, url, _webViewController);
+
     return Column(
       children: <Widget>[
         Flexible(
             child: WebView(
           javascriptMode: JavascriptMode.unrestricted,
-          initialUrl: _url,
+          initialUrl: url,
           onWebViewCreated: (controller) {
             _webViewController = controller;
           },


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
This fix solves the issue that causes the campus info card to load a 404 error page not found screen.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Add] - Added a "?" to the end of fileURL in campus_info_card.dart to prevent errors on the query string parameters. 


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

- [ ] Campus info card works as expected and reloads properly

- [ ] Nothing Changed in the rest of the app
