### PR TITLE
#856 Dark Mode Toggle Buttons

### DIFF
--- a/lib/ui/views/notifications/notifications_settings.dart
+++ b/lib/ui/views/notifications/notifications_settings.dart
@@ -32,7 +32,7 @@ class NotificationsSettingsView extends StatelessWidget {
             Provider.of<UserDataProvider>(context, listen: false)
                 .toggleNotifications(topic);
           },
-          activeColor: ColorPrimary,
+          activeColor: Theme.of(context).buttonColor,
         ),
       ));
     }

--- a/lib/ui/views/profile/cards_view.dart
+++ b/lib/ui/views/profile/cards_view.dart
@@ -66,7 +66,7 @@ class CardsView extends StatelessWidget {
           onChanged: (_) {
             _cardsDataProvider.toggleCard(card);
           },
-          activeColor: ColorPrimary,
+          activeColor: Theme.of(context).buttonColor,
         ),
       ));
     }


### PR DESCRIPTION
## Summary
In dark mode, the toggle buttons did not change color to match the mode and were difficult to see


## Changelog
 [General] [Fix] - Fixed toggle button color to change according to current mode 

## Test Plan
Tested on Samsung Galaxy S10+

![image](https://user-images.githubusercontent.com/49219707/94048357-3ed8da00-fd88-11ea-8e8e-20dd858251ab.png) ![image](https://user-images.githubusercontent.com/49219707/94048404-531cd700-fd88-11ea-95c2-a832dd2a3be5.png)
