### PR TITLE
Shuttle Now Retains Added Stops

### DIFF
--- a/lib/core/providers/shuttle.dart
+++ b/lib/core/providers/shuttle.dart
@@ -105,13 +105,13 @@ class ShuttleDataProvider extends ChangeNotifier {
   }
 
   Future<void> addStop(int stopID) async {
-    // print(stopID);
     if (!userDataProvider.userProfileModel.selectedStops.contains(stopID)) {
       userDataProvider.userProfileModel.selectedStops.add(stopID);
+      // update userprofilemodel after a stop is added
+      userDataProvider.updateUserProfileModel(userDataProvider.userProfileModel);
       // print("UDP - ${userDataProvider.userProfileModel.selectedStops}");
       arrivalsToRender[stopID] = await fetchArrivalInformation(stopID);
     }
-    // print('added');
     notifyListeners();
   }
 
@@ -211,8 +211,6 @@ class ShuttleDataProvider extends ChangeNotifier {
 
   Map<int, ShuttleStopModel> get stopsNotSelected {
     var output = new Map<int, ShuttleStopModel>.from(fetchedStops);
-    // print('stopsToRender length - ${stopsToRender.length}');
-    // print(stopsToRender.toString());
     for (ShuttleStopModel stop in stopsToRender) {
       output.remove(stop.id);
     }
@@ -223,7 +221,6 @@ class ShuttleDataProvider extends ChangeNotifier {
     arrivalsToRender[closestStop.id] =
         await fetchArrivalInformation(closestStop.id);
     for (ShuttleStopModel stop in stopsToRender) {
-      // print('stop ${stop.id}');
       arrivalsToRender[stop.id] = await fetchArrivalInformation(stop.id);
     }
   }


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
The shuttle card was not retaining stops that were added.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[CATEGORY] [TYPE] - Message
 [General] [Fix] - Updated UserProfileModel after every stop is added


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Verified that stop persistence works on Android, could not test on iOS.
