### PR TITLE
WebCard Performance and Reload Issue#1070

### DIFF
--- a/lib/ui/campus_info/campus_info_card.dart
+++ b/lib/ui/campus_info/campus_info_card.dart
@@ -13,7 +13,10 @@ class CampusInfoCard extends StatefulWidget {
   _CampusInfoCardState createState() => _CampusInfoCardState();
 }
 
-class _CampusInfoCardState extends State<CampusInfoCard> {
+class _CampusInfoCardState extends State<CampusInfoCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "campus_info";
   double _contentHeight = webViewMinHeight;
@@ -22,6 +25,7 @@ class _CampusInfoCardState extends State<CampusInfoCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return CardContainer(
       active: Provider.of<CardsDataProvider>(context).cardStates[cardId],
       hide: () => Provider.of<CardsDataProvider>(context, listen: false)

--- a/lib/ui/campus_info/campus_info_card.dart
+++ b/lib/ui/campus_info/campus_info_card.dart
@@ -15,7 +15,6 @@ class CampusInfoCard extends StatefulWidget {
 
 class _CampusInfoCardState extends State<CampusInfoCard>
     with AutomaticKeepAliveClientMixin {
-  @override
   bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "campus_info";

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -13,7 +13,10 @@ class ParkingCard extends StatefulWidget {
   _ParkingCardState createState() => _ParkingCardState();
 }
 
-class _ParkingCardState extends State<ParkingCard> {
+class _ParkingCardState extends State<ParkingCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
   ParkingDataProvider _parkingDataProvider;
   final _controller = new PageController();
   WebViewController _webViewController;
@@ -27,7 +30,9 @@ class _ParkingCardState extends State<ParkingCard> {
     _parkingDataProvider = Provider.of<ParkingDataProvider>(context);
   }
 
+  @override
   Widget build(BuildContext context) {
+    super.build(context);
     return CardContainer(
       titleText: CardTitleConstants.titleMap[cardId],
       isLoading: _parkingDataProvider.isLoading,

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -15,7 +15,6 @@ class ParkingCard extends StatefulWidget {
 
 class _ParkingCardState extends State<ParkingCard>
     with AutomaticKeepAliveClientMixin {
-  @override
   bool get wantKeepAlive => true;
   ParkingDataProvider _parkingDataProvider;
   final _controller = new PageController();

--- a/lib/ui/staff_id/staff_id_card.dart
+++ b/lib/ui/staff_id/staff_id_card.dart
@@ -13,7 +13,10 @@ class StaffIdCard extends StatefulWidget {
   _StaffIdCardState createState() => _StaffIdCardState();
 }
 
-class _StaffIdCardState extends State<StaffIdCard> {
+class _StaffIdCardState extends State<StaffIdCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "staff_id";
   double _contentHeight = 194.0;
@@ -22,6 +25,7 @@ class _StaffIdCardState extends State<StaffIdCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     _userDataProvider = Provider.of<UserDataProvider>(context);
     String webCardAuthURL = webCardURL +
         "?token=${_userDataProvider.authenticationModel.accessToken}&expiration=${_userDataProvider.authenticationModel.expiration}";

--- a/lib/ui/staff_id/staff_id_card.dart
+++ b/lib/ui/staff_id/staff_id_card.dart
@@ -15,7 +15,6 @@ class StaffIdCard extends StatefulWidget {
 
 class _StaffIdCardState extends State<StaffIdCard>
     with AutomaticKeepAliveClientMixin {
-  @override
   bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "staff_id";

--- a/lib/ui/staff_info/staff_info_card.dart
+++ b/lib/ui/staff_info/staff_info_card.dart
@@ -15,7 +15,6 @@ class StaffInfoCard extends StatefulWidget {
 
 class _StaffInfoCardState extends State<StaffInfoCard>
     with AutomaticKeepAliveClientMixin {
-  @override
   bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "staff_info";

--- a/lib/ui/staff_info/staff_info_card.dart
+++ b/lib/ui/staff_info/staff_info_card.dart
@@ -13,7 +13,10 @@ class StaffInfoCard extends StatefulWidget {
   _StaffInfoCardState createState() => _StaffInfoCardState();
 }
 
-class _StaffInfoCardState extends State<StaffInfoCard> {
+class _StaffInfoCardState extends State<StaffInfoCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "staff_info";
   double _contentHeight = cardContentMinHeight;
@@ -22,6 +25,7 @@ class _StaffInfoCardState extends State<StaffInfoCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return CardContainer(
       active: Provider.of<CardsDataProvider>(context).cardStates[cardId],
       hide: () => Provider.of<CardsDataProvider>(context, listen: false)

--- a/lib/ui/student_info/student_info_card.dart
+++ b/lib/ui/student_info/student_info_card.dart
@@ -13,7 +13,10 @@ class StudentInfoCard extends StatefulWidget {
   _StudentInfoCardState createState() => _StudentInfoCardState();
 }
 
-class _StudentInfoCardState extends State<StudentInfoCard> {
+class _StudentInfoCardState extends State<StudentInfoCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "student_info";
   double _contentHeight = cardContentMinHeight;
@@ -22,6 +25,7 @@ class _StudentInfoCardState extends State<StudentInfoCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return CardContainer(
       active: Provider.of<CardsDataProvider>(context).cardStates[cardId],
       hide: () => Provider.of<CardsDataProvider>(context, listen: false)

--- a/lib/ui/student_info/student_info_card.dart
+++ b/lib/ui/student_info/student_info_card.dart
@@ -15,7 +15,6 @@ class StudentInfoCard extends StatefulWidget {
 
 class _StudentInfoCardState extends State<StudentInfoCard>
     with AutomaticKeepAliveClientMixin {
-  @override
   bool get wantKeepAlive => true;
   WebViewController _webViewController;
   String cardId = "student_info";

--- a/lib/ui/survey/survey_card.dart
+++ b/lib/ui/survey/survey_card.dart
@@ -13,7 +13,10 @@ class SurveyCard extends StatefulWidget {
   _SurveyCardState createState() => _SurveyCardState();
 }
 
-class _SurveyCardState extends State<SurveyCard> {
+class _SurveyCardState extends State<SurveyCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
   String cardId = "student_survey";
   WebViewController _webViewController;
   double _contentHeight = cardContentMinHeight;
@@ -22,6 +25,7 @@ class _SurveyCardState extends State<SurveyCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return CardContainer(
       active: Provider.of<CardsDataProvider>(context).cardStates[cardId],
       hide: () => Provider.of<CardsDataProvider>(context, listen: false)

--- a/lib/ui/survey/survey_card.dart
+++ b/lib/ui/survey/survey_card.dart
@@ -15,7 +15,6 @@ class SurveyCard extends StatefulWidget {
 
 class _SurveyCardState extends State<SurveyCard>
     with AutomaticKeepAliveClientMixin {
-  @override
   bool get wantKeepAlive => true;
   String cardId = "student_survey";
   WebViewController _webViewController;


### PR DESCRIPTION


## Summary
<!-- What existing problem does the pull request solve? -->
Adds the AutomaticKeepAliveClientMixin to all of the webcards to prevent them from reloading when re-entering the viewport after scrolling. 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Fixed a bug causing severe performance and reload issues with the webcards


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

- [ ] Webcards do not reload when entering viewport after scrolling away

- [ ] Regular webcard functionality is maintained

- [ ] The view is not "jolty" when scrolling through the app
