### PR TITLE
Localization baseline setup for en, es

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,8 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key></key>
-	<string></string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>es</string>
+	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,6 @@
+{
+  "scannerTitle": "Scanner",
+  "@scannerTitle": {
+    "description": "Scanner card title"
+  }
+}

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,0 +1,3 @@
+{
+  "scannerTitle": "Escáner"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,8 @@ import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:campus_mobile_experimental/core/models/authentication.dart';
 import 'package:campus_mobile_experimental/core/models/user_profile.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -65,6 +67,15 @@ class CampusMobile extends StatelessWidget {
     return MultiProvider(
       providers: providers,
       child: MaterialApp(
+        localizationsDelegates: [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: [
+          const Locale('en', ''),
+          const Locale('es', ''),
+        ],
         debugShowCheckedModeBanner: true,
         title: 'UC San Diego',
         theme: ThemeData(

--- a/lib/ui/scanner/scanner_view.dart
+++ b/lib/ui/scanner/scanner_view.dart
@@ -3,6 +3,7 @@ import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:campus_mobile_experimental/core/providers/user.dart';
 import 'package:campus_mobile_experimental/core/services/barcode.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_scandit_plugin/flutter_scandit_plugin.dart';
 import 'package:intl/intl.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -76,7 +77,7 @@ class _ScanditScannerState extends State<ScanditScanner> {
         preferredSize: Size.fromHeight(42),
         child: AppBar(
           centerTitle: true,
-          title: const Text("Scanner"),
+          title: Text(AppLocalizations.of(context).scannerTitle),
         ),
       ),
       body: !hasScanned ? renderScanner() : renderSubmissionView(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,7 +154,7 @@ packages:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   cli_util:
     dependency: transitive
     description:
@@ -668,7 +668,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.7"
   qr:
     dependency: transitive
     description:
@@ -743,7 +743,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.9"
+    version: "0.9.10"
   source_span:
     dependency: transitive
     description:
@@ -806,7 +806,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.1.1+3"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,6 +330,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -446,7 +451,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.0"
+    version: "0.16.1"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,10 @@ dependencies:
   firebase_analytics: 5.0.2
   firebase_core: 0.4.4
   firebase_messaging: 6.0.13
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_scandit_plugin:
     git:
       url: https://github.com/UCSD/flutter_scandit.git
@@ -28,12 +32,10 @@ dependencies:
   flutter_linkify: 3.1.3
   flutter_secure_storage: 3.3.1+1
   flutter_sticky_header: 0.4.0
-  flutter:
-    sdk: flutter
   google_maps_flutter: 1.0.2
   hive_flutter: 0.3.1
   hive: 1.4.4+1
-  intl: 0.16.0
+  intl: 0.16.1
   location: 3.0.2
   package_info: 0.4.0+18
   path_provider: 1.6.8
@@ -56,6 +58,7 @@ dev_dependencies:
     sdk: flutter
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/images/


### PR DESCRIPTION
## Summary
Localization baseline setup for en, es

## Changelog
[General][Add] - Add baseline localization functionality
[General][Add] - Add en localization support
[General][Add] - Add es localization support
[General][Add] - Add en, es localization test to native Scanner view title

## Setup
1. Define en and es translations in their respective template files
Example:
```dart
// lib/l10n/app_en.arb
{
  "scannerTitle": "Scanner",
  "@scannerTitle": {
    "description": "Scanner card title"
  }
}

// lib/l10n/app_es.arb
{
  "scannerTitle": "Escáner"
}
```

2. Implement translation definitions
```dart
import 'package:flutter_gen/gen_l10n/app_localizations.dart';
// ...
title: Text(AppLocalizations.of(context).scannerTitle),
```

3. Build and run
```
flutter run
```

## Docs
 - [Internationalizing Flutter apps docs](https://flutter.dev/docs/development/accessibility-and-localization/internationalization)

## Test Plan
- Ensure localized translations reflect the language selection at the mobile OS level

## Screenshots
<img src="https://user-images.githubusercontent.com/15112294/101954675-59fdfd80-3bb1-11eb-9592-6d1d8297da2e.png" width="300">   <img src="https://user-images.githubusercontent.com/15112294/101954679-5ec2b180-3bb1-11eb-97d1-fa9d28f974c2.png" width="300">
