### PR TITLE
Shuttle Stop Persistence Fix

### DIFF
--- a/lib/core/providers/shuttle.dart
+++ b/lib/core/providers/shuttle.dart
@@ -107,10 +107,8 @@ class ShuttleDataProvider extends ChangeNotifier {
   Future<void> addStop(int stopID) async {
     if (!userDataProvider.userProfileModel.selectedStops.contains(stopID)) {
       userDataProvider.userProfileModel.selectedStops.add(stopID);
-      // update userprofilemodel after a stop is added
-      // userDataProvider
-      //     .updateUserProfileModel(userDataProvider.userProfileModel);
-      // print("UDP - ${userDataProvider.userProfileModel.selectedStops}");
+      // update userprofilemodel locally and in database after a stop is added
+      userDataProvider.postUserProfile(userDataProvider.userProfileModel);
       arrivalsToRender[stopID] = await fetchArrivalInformation(stopID);
     }
     notifyListeners();
@@ -120,6 +118,8 @@ class ShuttleDataProvider extends ChangeNotifier {
     // print('remove');
     if (userDataProvider.userProfileModel.selectedStops.contains(stopID)) {
       userDataProvider.userProfileModel.selectedStops.remove(stopID);
+      // update userprofilemodel locally and in database after a stop is removed
+      userDataProvider.postUserProfile(userDataProvider.userProfileModel);
       // print("UDP - ${userDataProvider.userProfileModel.selectedStops}");
     }
     notifyListeners();


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
The mobile app would not remember the stops that have been saved after app close.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General][Add] - Updating UserProfile to database as well as in local storage via Hive whenever selected stops changes
**Note:** Previous PR tried to only use local storage, not the MobilePlatform-Registration API. This PR now uses both approaches to save state.

## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
#### Extensive testing process since initial PR failed further regression testing

1. Verified on various Android simulators (Pixel 2 and Pixel 3)
Confirmed that the user interface is now remembering added stops as well as removed stops on the same device.
https://user-images.githubusercontent.com/13931192/103249624-04518100-4925-11eb-9267-1eda9e0c188c.mov

2. Verified proper MobilePlatform-Registration API behavior (QA endpoint)
MobilePlatform-Registration QA updates properly when the selectedStops attribute changes, verified in Postman using GET on /profile.

3. Verified stops are remembered on other devices
Installed TestFlight build 124 (7.2.15 QA) and added/removed stops on simulator running PR code, behavior was reflected in the TestFlight build as well. Cannot confirm other way (TestFlight changes --> Android) as this code is not merged in.


