### PR TITLE
add obscure password state on login forms

### DIFF
--- a/lib/ui/onboarding/onboarding_login.dart
+++ b/lib/ui/onboarding/onboarding_login.dart
@@ -129,7 +129,7 @@ class _OnboardingLoginState extends State<OnboardingLogin> {
                     fillColor: Colors.white,
                     filled: true,
                   ),
-                  obscureText: true,
+                  obscureText: _passwordObscured,
                   controller: _passwordTextFieldController,
                 ),
               ),

--- a/lib/ui/onboarding/onboarding_login.dart
+++ b/lib/ui/onboarding/onboarding_login.dart
@@ -15,6 +15,7 @@ class _OnboardingLoginState extends State<OnboardingLogin> {
   final _emailTextFieldController = TextEditingController();
   final _passwordTextFieldController = TextEditingController();
   UserDataProvider _userDataProvider;
+  bool _passwordObscured = true;
 
   @override
   void didChangeDependencies() {
@@ -101,6 +102,16 @@ class _OnboardingLoginState extends State<OnboardingLogin> {
                   ),
                   decoration: InputDecoration(
                     hintText: 'Password',
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        // Based on passwordObscured state choose the icon
+                        _passwordObscured
+                            ? Icons.visibility_off
+                            : Icons.visibility,
+                        color: Theme.of(context).primaryColorDark,
+                      ),
+                      onPressed: () => _toggle(),
+                    ),
                     focusedBorder: OutlineInputBorder(
                       borderSide: BorderSide(
                         color: Colors.black,
@@ -207,6 +218,13 @@ class _OnboardingLoginState extends State<OnboardingLogin> {
         ),
       ),
     );
+  }
+
+  // Toggles the password show status
+  void _toggle() {
+    setState(() {
+      _passwordObscured = !_passwordObscured;
+    });
   }
 
   Widget showAlertDialog(BuildContext context) {

--- a/lib/ui/profile/login.dart
+++ b/lib/ui/profile/login.dart
@@ -12,6 +12,7 @@ class _LoginState extends State<Login> {
   final _emailTextFieldController = TextEditingController();
   final _passwordTextFieldController = TextEditingController();
   UserDataProvider _userDataProvider;
+  bool _passwordObscured = true;
 
   @override
   void didChangeDependencies() {
@@ -96,10 +97,19 @@ class _LoginState extends State<Login> {
             TextField(
               decoration: InputDecoration(
                 hintText: 'Password',
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    // Based on passwordObscured state choose the icon
+                    _passwordObscured ? Icons.visibility_off : Icons.visibility,
+                    color: Theme.of(context).primaryColorDark,
+                  ),
+                  onPressed: () => _toggle(),
+                ),
                 border: OutlineInputBorder(),
                 labelText: 'Password',
               ),
-              obscureText: true,
+              obscureText: _passwordObscured,
+              keyboardType: TextInputType.emailAddress,
               controller: _passwordTextFieldController,
             ),
             SizedBox(height: 10),
@@ -144,6 +154,13 @@ class _LoginState extends State<Login> {
         ),
       ),
     );
+  }
+
+  // Toggles the password show status
+  void _toggle() {
+    setState(() {
+      _passwordObscured = !_passwordObscured;
+    });
   }
 
   Widget showAlertDialog(BuildContext context) {


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->

User can now see the password they are inputting into the text fields.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Add] - option to obscure password while inputing into text fields


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
 - need to verify that the login still functions as intended when password is showing and when password is obscured 
 - repeat test on profile tab and onboarding screen
