### PR TITLE
change text on failed login prompt

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -112,6 +112,12 @@ class ScannerConstants {
       'Your session has expired. Please login to submit a scan.';
 }
 
+class LoginConstants {
+  static const loginFailedTitle = 'Sorry, unable to sign you in.';
+  static const loginFailedDesc =
+      'Be sure you are using the correct credentials; TritonLink login if you are a student, SSO (AD or Active Directory) if you are a Faculty/Staff.';
+}
+
 class Plugins {
   static const FrontCamera = 'FRONT CAMERA';
 }

--- a/lib/ui/onboarding/onboarding_login.dart
+++ b/lib/ui/onboarding/onboarding_login.dart
@@ -220,9 +220,8 @@ class _OnboardingLoginState extends State<OnboardingLogin> {
 
     // set up the AlertDialog
     AlertDialog alert = AlertDialog(
-      title: Text("Sorry, unable to sign you in"),
-      content: Text(
-          "Be sure you are using the correct credentials; TritonLink login if you are a student, SSO if you are Faculty/Staff."),
+      title: Text(LoginConstants.loginFailedTitle),
+      content: Text(LoginConstants.loginFailedDesc),
       actions: [
         okButton,
       ],

--- a/lib/ui/profile/login.dart
+++ b/lib/ui/profile/login.dart
@@ -1,3 +1,4 @@
+import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/core/providers/user.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -157,9 +158,8 @@ class _LoginState extends State<Login> {
 
     // set up the AlertDialog
     AlertDialog alert = AlertDialog(
-      title: Text("Sorry, unable to sign you in"),
-      content: Text(
-          "Be sure you are using the correct credentials; TritonLink login if you are a student, SSO if you are Faculty/Staff."),
+      title: Text(LoginConstants.loginFailedTitle),
+      content: Text(LoginConstants.loginFailedDesc),
       actions: [
         okButton,
       ],


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->

Changed text on failed login prompt.
## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Change] - Text on failed login prompt


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Test by verifying that the failed login prompt says the following:
"Be sure you are using the correct credentials; TritonLink login if you are a student, SSO (AD or Active Directory) if you are a Faculty/Staff."
