### PR TITLE
Upgrade permission_handler to resolve PlatformException error

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -122,7 +122,7 @@ PODS:
     - Flutter
   - path_provider (0.0.1):
     - Flutter
-  - "permission_handler (5.0.1+1)":
+  - "permission_handler (5.1.0+2)":
     - Flutter
   - PromisesObjC (1.2.12)
   - Protobuf (3.11.4)
@@ -244,7 +244,7 @@ SPEC CHECKSUMS:
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
-  permission_handler: eac8e15b4a1a3fba55b761d19f3f4e6b005d15b6
+  permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
   ScanditBarcodeCapture: 80517b2725abfa0c8d55ef12e83896e9285d363f

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.7"
   build_resolvers:
     dependency: transitive
     description:
@@ -390,7 +390,7 @@ packages:
       name: google_maps_flutter_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   graphs:
     dependency: transitive
     description:
@@ -600,14 +600,14 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1+1"
+    version: "5.1.0+2"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   platform:
     dependency: transitive
     description:
@@ -642,7 +642,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   provider:
     dependency: "direct main"
     description:
@@ -726,7 +726,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   shared_preferences: 0.5.6+3
   url_launcher: 5.2.5
   uuid: 2.2.0
-  permission_handler: ^5.0.1+1
+  permission_handler: ^5.0.1+2
   webview_flutter:
     git:
       path: packages/webview_flutter


### PR DESCRIPTION
## Changelog
[General][Fix] - Permission handler upgrade to resolve PlatformException compilation error in Flutter 1.22.6

## Test Plan Items
- Regression test user permissions: camera, location, notifications, and wayfinding