### PR TITLE
Webcard Redirect

### DIFF
--- a/lib/core/services/cards.dart
+++ b/lib/core/services/cards.dart
@@ -20,7 +20,7 @@ class CardsService {
     /// API Manager Service
     try {
       String cardListEndpoint =
-          "https://api-qa.ucsd.edu:8243/defaultcards/v4.0.0/defaultcards?ucsdaffiliation=${ucsdAffiliation}";
+          "https://mobile.ucsd.edu/replatform/v1/qa/webview/mihir-test/student_cards-v4.json";
       String _response =
           await _networkHelper.authorizedFetch(cardListEndpoint, headers);
       _cardsModel = cardsModelFromJson(_response);

--- a/lib/core/services/cards.dart
+++ b/lib/core/services/cards.dart
@@ -20,9 +20,9 @@ class CardsService {
     /// API Manager Service
     try {
       String cardListEndpoint =
-          "https://mobile.ucsd.edu/replatform/v1/qa/webview/mihir-test/student_cards-v4.json";
+          "https://api-qa.ucsd.edu:8243/defaultcards/v4.0.0/defaultcards?ucsdaffiliation=${ucsdAffiliation}";
       String _response =
-          await _networkHelper.authorizedFetch(cardListEndpoint, headers);
+      await _networkHelper.authorizedFetch(cardListEndpoint, headers);
       _cardsModel = cardsModelFromJson(_response);
       _isLoading = false;
       return true;
@@ -58,7 +58,7 @@ class CardsService {
     final Map<String, String> tokenHeaders = {
       "content-type": 'application/x-www-form-urlencoded',
       "Authorization":
-          "Basic djJlNEpYa0NJUHZ5akFWT0VRXzRqZmZUdDkwYTp2emNBZGFzZWpmaWZiUDc2VUJjNDNNVDExclVh"
+      "Basic djJlNEpYa0NJUHZ5akFWT0VRXzRqZmZUdDkwYTp2emNBZGFzZWpmaWZiUDc2VUJjNDNNVDExclVh"
     };
     try {
       var response = await _networkHelper.authorizedPost(

--- a/lib/ui/common/webview_container.dart
+++ b/lib/ui/common/webview_container.dart
@@ -111,7 +111,6 @@ class _WebViewContainerState extends State<WebViewContainer>
 
   // builds the actual webview widget
   Widget buildBody(context) {
-    print("webview_container.dart:114");
     return Container(
       height: _contentHeight,
       child: WebView(
@@ -120,7 +119,6 @@ class _WebViewContainerState extends State<WebViewContainer>
         initialUrl: webCardUrl,
         onWebViewCreated: (controller) {
           _webViewController = controller;
-          print("CURRENT_URL: ${_webViewController.currentUrl().toString()}");
         },
         navigationDelegate: null,
         javascriptChannels: <JavascriptChannel>[
@@ -195,8 +193,7 @@ class _WebViewContainerState extends State<WebViewContainer>
       name: 'OpenLink',
       onMessageReceived: (JavascriptMessage message) {
         print("in links channel");
-        print("MESSAGE: ${message}");
-//        openLink(message.message);
+        openLink(message.message);
       },
     );
   }
@@ -243,11 +240,11 @@ class _WebViewContainerState extends State<WebViewContainer>
     );
   }
 
+  // javascript channel for redirecting the user to a new webcard URL
   JavascriptChannel _permanentRedirect(BuildContext context) {
     return JavascriptChannel(
       name: 'Redirect',
       onMessageReceived: (JavascriptMessage message) async {
-        print("IN PERMANENT REDIRECT, MESSAGE: ${message.message}");
         webCardUrl = message.message;
         _webViewController.loadUrl(message.message);
       },
@@ -261,7 +258,6 @@ class _WebViewContainerState extends State<WebViewContainer>
   // to the webViewController's url, and loads in the new url if so
   void checkWebURL() async {
     String currentUrl = await _webViewController?.currentUrl();
-    print("CURRENT_URL (webview_container.dart:249): ${currentUrl}");
     if (_webViewController != null && webCardUrl != currentUrl) {
       _webViewController?.loadUrl(webCardUrl);
     }

--- a/lib/ui/common/webview_container.dart
+++ b/lib/ui/common/webview_container.dart
@@ -111,6 +111,7 @@ class _WebViewContainerState extends State<WebViewContainer>
 
   // builds the actual webview widget
   Widget buildBody(context) {
+    print("webview_container.dart:114");
     return Container(
       height: _contentHeight,
       child: WebView(
@@ -119,12 +120,15 @@ class _WebViewContainerState extends State<WebViewContainer>
         initialUrl: webCardUrl,
         onWebViewCreated: (controller) {
           _webViewController = controller;
+          print("CURRENT_URL: ${_webViewController.currentUrl().toString()}");
         },
+        navigationDelegate: null,
         javascriptChannels: <JavascriptChannel>[
           _linksChannel(context),
           _heightChannel(context),
           _mapChannel(context),
-          _refreshTokenChannel(context)
+          _refreshTokenChannel(context),
+          _permanentRedirect(context)
         ].toSet(),
       ),
     );
@@ -191,7 +195,8 @@ class _WebViewContainerState extends State<WebViewContainer>
       name: 'OpenLink',
       onMessageReceived: (JavascriptMessage message) {
         print("in links channel");
-        openLink(message.message);
+        print("MESSAGE: ${message}");
+//        openLink(message.message);
       },
     );
   }
@@ -238,10 +243,25 @@ class _WebViewContainerState extends State<WebViewContainer>
     );
   }
 
+  JavascriptChannel _permanentRedirect(BuildContext context) {
+    return JavascriptChannel(
+      name: 'Redirect',
+      onMessageReceived: (JavascriptMessage message) async {
+        print("IN PERMANENT REDIRECT, MESSAGE: ${message.message}");
+        webCardUrl = message.message;
+        _webViewController.loadUrl(message.message);
+      },
+    );
+  }
+
+
+
+
   // this function checks to see if the current url of the state is different
   // to the webViewController's url, and loads in the new url if so
   void checkWebURL() async {
     String currentUrl = await _webViewController?.currentUrl();
+    print("CURRENT_URL (webview_container.dart:249): ${currentUrl}");
     if (_webViewController != null && webCardUrl != currentUrl) {
       _webViewController?.loadUrl(webCardUrl);
     }


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Reloading a webcard that had been redirected to a new link reloaded the original URL

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Add] - JavaScript channel for receiving and setting the webcard URL (and then redirecting via controller)


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
To test, create a WebCard that links to a new page (web-side code can be found at https://cms.ucsd.edu/entity/open.act?id=3c25c5860aaf6b3a6003b057e4509b4f&type=file. Clicking on the link should redirect to the link defined on the card, and any in-app navigation (reloading, changing views, etc) should stay on the new link.
