### PR TITLE
Wayfinding Permissions Provider Exception Fix

### DIFF
--- a/lib/app_provider.dart
+++ b/lib/app_provider.dart
@@ -26,6 +26,7 @@ import 'package:campus_mobile_experimental/core/providers/weather.dart';
 import 'package:campus_mobile_experimental/ui/navigator/top.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_analytics/observer.dart';
+import 'package:location/location.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 
@@ -34,7 +35,7 @@ List<SingleChildWidget> providers = [
   ...dependentServices,
   ...uiConsumableProviders,
 ];
-
+LocationDataProvider locationProvider;
 final FirebaseAnalytics analytics = FirebaseAnalytics();
 final FirebaseAnalyticsObserver observer =
     FirebaseAnalyticsObserver(analytics: analytics);
@@ -82,7 +83,8 @@ List<SingleChildWidget> independentServices = [
   StreamProvider<Coordinates>(
     create: (_) {
       print("CreateProvider: Coordinates (LocationDataProvider)");
-      return LocationDataProvider().locationStream;
+      locationProvider = LocationDataProvider();
+      return locationProvider.locationStream;
     },
     lazy: false,
   ),
@@ -194,7 +196,7 @@ List<SingleChildWidget> dependentServices = [
     return proximityAwarenessSingleton;
   }, update: (_, coordinates, userDataProvider, proximityAwarenessSingleton) {
     print("UpdateProvider: AdvancedWayfindingSingleton");
-    proximityAwarenessSingleton.coordinates = coordinates;
+    proximityAwarenessSingleton.coordinateAndLocation(coordinates, locationProvider);
     proximityAwarenessSingleton.userProvider = userDataProvider;
     return proximityAwarenessSingleton;
   }),

--- a/lib/core/providers/location.dart
+++ b/lib/core/providers/location.dart
@@ -12,7 +12,7 @@ class LocationDataProvider extends ChangeNotifier{
   StreamController<Coordinates> _locationController =
   StreamController<Coordinates>.broadcast();
   Stream<Coordinates> get locationStream => _locationController.stream;
-
+  Location get locationObject => _locationService;
   LocationDataProvider() {
     locationStream;
     _init();

--- a/lib/core/providers/wayfinding.dart
+++ b/lib/core/providers/wayfinding.dart
@@ -11,12 +11,14 @@ import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_networking.dart';
 import 'package:campus_mobile_experimental/core/models/location.dart';
 import 'package:campus_mobile_experimental/core/models/wayfinding_constants.dart';
+import 'package:campus_mobile_experimental/core/providers/location.dart';
 import 'package:campus_mobile_experimental/core/providers/user.dart';
 import 'package:campus_mobile_experimental/core/services/wayfinding.dart';
 import 'package:campus_mobile_experimental/core/utils/maps.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:location/location.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'bluetooth.dart';
@@ -64,6 +66,9 @@ class WayfindingProvider extends ChangeNotifier {
 
   /// Provides location of device for logging scans.
   Coordinates _coordinates;
+
+  /// Not directly accessed but used to check permissions
+  LocationDataProvider _locationDataProvider;
 
   /// Keeps track of scanned unique BT devices.
   HashMap<String, BluetoothDeviceProfile> scannedObjects = new HashMap();
@@ -140,8 +145,6 @@ class WayfindingProvider extends ChangeNotifier {
           await _wayfindingService.fetchData();
           _wayfindingConstantsModel =
               _wayfindingService.wayfindingConstantsModel;
-          print(
-              "Wayfinding is : ${_wayfindingConstantsModel == null ? "NULL" : "NOT NULL"}");
 
           // Set up broadcasting for UCSD App Identification
           startBeaconBroadcast();
@@ -790,7 +793,8 @@ class WayfindingProvider extends ChangeNotifier {
     beaconSingleton?.beaconBroadcast?.stop();
   }
 
-  set coordinates(Coordinates value) {
+  void coordinateAndLocation(Coordinates value, LocationDataProvider locationDataProvider) {
+    _locationDataProvider = locationDataProvider;
     // Toggle off 'force off" value
     if(_coordinates!= null){
       forceOff = false;
@@ -822,9 +826,10 @@ class WayfindingProvider extends ChangeNotifier {
 
   // Checks bt state of the device
   bool permissionState(BuildContext context, AsyncSnapshot<dynamic> snapshot) {
-    checkAdvancedWayfindingEnabled();
+
+   // checkAdvancedWayfindingEnabled();
     if (snapshot.data as BluetoothState == BluetoothState.unauthorized ||
-        snapshot.data as BluetoothState == BluetoothState.off) {
+        snapshot.data as BluetoothState == BluetoothState.off || forceOff) {
       forceOff = true;
       advancedWayfindingEnabled = false;
     } else {
@@ -850,6 +855,13 @@ class WayfindingProvider extends ChangeNotifier {
   /// permissionGranted = true
   /// forceOff (currently false)
   void startBluetooth(BuildContext context, bool permissionGranted) async {
+
+    if (PermissionStatus.granted != await _locationDataProvider.locationObject.hasPermission()){
+      advancedWayfindingEnabled = false;
+      forceOff = true;
+      notifyListeners();
+      print("detected no permission");
+    }
     if (forceOff) return;
 //    print("wayfinging enabled");
 //    print(advancedWayfindingEnabled);
@@ -864,6 +876,7 @@ class WayfindingProvider extends ChangeNotifier {
     } else {
       forceOff = false;
     }
+    notifyListeners();
   }
 
   // Sets up signal broadcasting with a random UUID

--- a/lib/ui/wayfinding/wayfinding_permissions.dart
+++ b/lib/ui/wayfinding/wayfinding_permissions.dart
@@ -310,7 +310,7 @@ class _AdvancedWayfindingPermissionState
   }
 
   void startBluetooth(BuildContext context, bool permissionGranted) async {
-    _bluetoothSingleton = Provider.of<AdvancedWayfindingSingleton>(context);
+    _bluetoothSingleton = Provider.of<AdvancedWayfindingSingleton>(context, listen: false);
     if (_bluetoothSingleton.userDataProvider == null) {
       _bluetoothSingleton.userDataProvider =
           Provider.of<UserDataProvider>(context);


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Resolved exception:
`Unhandled Exception: 'package:provider/src/provider.dart': Failed assertion: line 265 pos 7: 'context.owner!.debugBuilding ||
E/flutter (17709):           listen == false ||
E/flutter (17709):           debugIsInInheritedProviderUpdate': Tried to listen to a value exposed with provider, from outside of the widget tree.`

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Fix a bug causing exceptions in wayfinding_permissions.dart


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Verify previous exception no longer occurs.
