### PR TITLE
Resolve immutable warnings

### DIFF
--- a/lib/ui/availability/manage_availability_view.dart
+++ b/lib/ui/availability/manage_availability_view.dart
@@ -4,7 +4,11 @@ import 'package:campus_mobile_experimental/ui/common/container_view.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class ManageAvailabilityView extends StatelessWidget {
+class ManageAvailabilityView extends StatefulWidget {
+  _ManageAvailabilityViewState createState() => _ManageAvailabilityViewState();
+}
+
+class _ManageAvailabilityViewState extends State<ManageAvailabilityView> {
   AvailabilityDataProvider _availabilityDataProvider;
 
   @override

--- a/lib/ui/parking/manage_parking_view.dart
+++ b/lib/ui/parking/manage_parking_view.dart
@@ -4,7 +4,10 @@ import 'package:campus_mobile_experimental/ui/common/container_view.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class ManageParkingView extends StatelessWidget {
+class ManageParkingView extends StatefulWidget {
+  _ManageParkingViewState createState() => _ManageParkingViewState();
+}
+class _ManageParkingViewState extends State<ManageParkingView> {
   ParkingDataProvider parkingDataProvider;
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -5,7 +5,12 @@ import 'package:campus_mobile_experimental/ui/common/container_view.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class SpotTypesView extends StatelessWidget {
+class SpotTypesView extends StatefulWidget {
+  @override
+  _SpotTypesViewState createState() => _SpotTypesViewState();
+}
+
+class _SpotTypesViewState extends State<SpotTypesView> {
   ParkingDataProvider spotTypesDataProvider;
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/profile/cards.dart
+++ b/lib/ui/profile/cards.dart
@@ -3,7 +3,11 @@ import 'package:campus_mobile_experimental/ui/common/container_view.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class CardsView extends StatelessWidget {
+class CardsView extends StatefulWidget {
+  _CardsViewState createState() => _CardsViewState();
+}
+
+class _CardsViewState extends State<CardsView> {
   CardsDataProvider _cardsDataProvider;
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/scanner/native_scanner_view.dart
+++ b/lib/ui/scanner/native_scanner_view.dart
@@ -9,7 +9,11 @@ import 'package:intl/intl.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
-class ScanditScanner extends StatelessWidget {
+class ScanditScanner extends StatefulWidget {
+  _ScanditScannerState createState() => _ScanditScannerState();
+}
+
+class _ScanditScannerState extends State<ScanditScanner> {
   ScannerDataProvider _scannerDataProvider;
   UserDataProvider _userDataProvider;
   set userDataProvider(UserDataProvider value) => _userDataProvider = value;

--- a/lib/ui/shuttle/manage_shuttle_view.dart
+++ b/lib/ui/shuttle/manage_shuttle_view.dart
@@ -7,7 +7,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
-class ManageShuttleView extends StatelessWidget {
+class ManageShuttleView extends StatefulWidget {
+  _ManageShuttleViewState createState() => _ManageShuttleViewState();
+}
+
+class _ManageShuttleViewState extends State<ManageShuttleView> {
   ShuttleDataProvider _shuttleDataProvider;
 
   @override


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
The Dart compiler was showing warnings with the form "info: This class (or a class that this class inherits from) is marked as '@immutable', but one or more of its instance fields aren't final." 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[ManageAvailabilityView] [Fix] - Convert to StatefulWidget
[ManageParkingView] [Fix] - Convert to StatefulWidget
[SpotTypesView] [Fix] - Convert to StatefulWidget
[CardsView] [Fix] - Convert to StatefulWidget
[NativeScannerView] [Fix] - Convert to StatefulWidget
[ManageShuttleView] [Fix] - Convert to StatefulWidget

## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Test the following components above to verify their behavior is unchanged from v7.7. The native scanner requires rigorous testing as it is a highly sensitive feature.  
