### PR TITLE
Speed Test Default Enabled

### DIFF
--- a/lib/core/providers/cards.dart
+++ b/lib/core/providers/cards.dart
@@ -30,6 +30,7 @@ class CardsDataProvider extends ChangeNotifier {
       'parking',
       'news',
       'weather',
+      'speed_test',
     ];
 
     // Native student cards
@@ -38,7 +39,6 @@ class CardsDataProvider extends ChangeNotifier {
       'schedule',
       'student_survey',
       'student_id',
-      'speed_test',
     ];
 
     // Native staff cards
@@ -46,7 +46,6 @@ class CardsDataProvider extends ChangeNotifier {
       'MyUCSDChart',
       'staff_info',
       'employee_id',
-      'speed_test',
     ];
 
     for (String card in CardTitleConstants.titleMap.keys.toList()) {


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Closes #1360 . Speed test now enabled for visitors, staff and students.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General][Fix] - Enabled WiFi Speed Test on all affiliations.

## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Ensure speed test card is enabled by default when logged in as staff, logged in as student and visitors.
