### PR TITLE
Package upgrade: google_maps_flutter 2.0.4 --> 2.0.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter_secure_storage: 4.1.0
   flutter_sticky_header: 0.6.0
   get: 4.1.4
-  google_maps_flutter: 2.0.4
+  google_maps_flutter: 2.0.5
   hive: 2.0.4
   hive_flutter: 1.0.0
   intl: 0.17.0


### PR DESCRIPTION
## Summary
Package upgrade: google_maps_flutter 2.0.4 --> 2.0.5

## Changelog
[General] [Change] - Upgrade `google_maps_flutter` from `2.0.4` to `2.0.5` ([changelog](https://pub.dev/packages/google_maps_flutter/changelog))

## Test Plan
Regression test the following areas:
```
./lib/ui/map/my_location_button.dart
./lib/ui/map/map.dart
./lib/ui/map/directions_button.dart
./lib/core/providers/map.dart

```