### PR TITLE
Package upgrade: firebase_crashlytics 2.0.3 --> 2.0.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   encrypt: 5.0.0
   firebase_analytics: 8.0.4
   firebase_core: 1.1.1
-  firebase_crashlytics: 2.0.3
+  firebase_crashlytics: 2.0.4
   firebase_messaging: 9.1.4
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Summary
Package upgrade: firebase_crashlytics 2.0.3 --> 2.0.4

## Changelog
[General] [Change] - Upgrade `firebase_crashlytics` from `2.0.3` to `2.0.4` ([changelog](https://pub.dev/packages/firebase_crashlytics/changelog))

## Test Plan
Regression test the following areas:
```
./lib/main.dart

```