### PR TITLE
Remove duplicate entry in card list

### DIFF
--- a/lib/core/providers/cards.dart
+++ b/lib/core/providers/cards.dart
@@ -30,7 +30,6 @@ class CardsDataProvider extends ChangeNotifier {
       'parking',
       'news',
       'weather',
-      'speed_test',
     ];
 
     // Native student cards


### PR DESCRIPTION
## Summary
Remove duplicate `speed_test` entry in card order list

## Changelog
[General] [Fix] - Remove duplicate `speed_test` entry in card order list

## Test Plan
- Test Speed Test card
- Verify duplicate speed test card removed for all affiliations in Home and Card Management