### PR TITLE
Scan retry button

### DIFF
--- a/lib/core/providers/cards.dart
+++ b/lib/core/providers/cards.dart
@@ -30,7 +30,6 @@ class CardsDataProvider extends ChangeNotifier {
       'parking',
       'news',
       'weather',
-      'speed_test',
     ];
 
     // Native student cards

--- a/lib/ui/scanner/native_scanner_view.dart
+++ b/lib/ui/scanner/native_scanner_view.dart
@@ -138,20 +138,20 @@ class _ScanditScannerState extends State<ScanditScanner> {
                     style: TextStyle(fontSize: 15)),
               ),
               Padding(
-                padding: EdgeInsets.only(top: 16.0),
-                child: TextButton(
-                  style: TextButton.styleFrom(
-                      padding: EdgeInsets.only(left: 32.0, right: 32.0),
-                      primary: lightButtonColor,
-                      textStyle: TextStyle(
-                        color: Colors.white,
-                      )),
+                padding: EdgeInsets.only(top: 24.0),
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    padding: EdgeInsets.only(left: 32.0, right: 32.0),
+                    primary: Theme.of(context).buttonColor,
+                  ),
                   onPressed: () {
                     _scannerDataProvider.setDefaultStates();
                   },
                   child: Text(
                     "Try again",
-                    style: TextStyle(fontSize: 18.0),
+                    style: TextStyle(
+                        fontSize: 18.0,
+                        color: Theme.of(context).textTheme.button.color),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
Fix color inversion on scanner retry button


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Fix color inversion on scanner retry button


## Test Plan
- Ensure scanner retry button renders as expected in light and dark mode on iOS and Android

