### PR TITLE
Fixed SCANNED_DEVICE_ADVERTISEMENT_ID Format

### DIFF
--- a/lib/core/providers/wayfinding.dart
+++ b/lib/core/providers/wayfinding.dart
@@ -383,7 +383,6 @@ class WayfindingProvider extends ChangeNotifier {
           "-" +
           calculatedUUID.substring(20);
     }
-    print("Calculated UUID: " + calculatedUUID);
     return calculatedUUID;
   }
 

--- a/lib/core/providers/wayfinding.dart
+++ b/lib/core/providers/wayfinding.dart
@@ -1,5 +1,3 @@
-
-
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
@@ -373,6 +371,19 @@ class WayfindingProvider extends ChangeNotifier {
       calculatedUUID = calculateHexFromArray(
           decimalArray); //https://stackoverflow.com/questions/60902976/flutter-ios-to-ios-broadcast-beacon-not-working
     });
+    //Add formatting to applicable uuid
+    if (calculatedUUID.length == 30) {
+      calculatedUUID = calculatedUUID.substring(0, 8) +
+          "-" +
+          calculatedUUID.substring(8, 12) +
+          "-" +
+          calculatedUUID.substring(12, 16) +
+          "-" +
+          calculatedUUID.substring(16, 20) +
+          "-" +
+          calculatedUUID.substring(20);
+    }
+    print("Calculated UUID: " + calculatedUUID);
     return calculatedUUID;
   }
 
@@ -540,7 +551,8 @@ class WayfindingProvider extends ChangeNotifier {
       } else if (!isDeviceContinuous &&
           value.scanIntervalAllowancesUsed! <
               _wayfindingConstantsModel.scanIntervalAllowance!) {
-        value.scanIntervalAllowancesUsed = value.scanIntervalAllowancesUsed! + 1;
+        value.scanIntervalAllowancesUsed =
+            value.scanIntervalAllowancesUsed! + 1;
       }
       return false;
     });
@@ -554,7 +566,8 @@ class WayfindingProvider extends ChangeNotifier {
       } else if (!value.continuousDuration! &&
           value.scanIntervalAllowancesUsed! <=
               _wayfindingConstantsModel.scanIntervalAllowance!) {
-        value.scanIntervalAllowancesUsed = value.scanIntervalAllowancesUsed! + 1;
+        value.scanIntervalAllowancesUsed =
+            value.scanIntervalAllowancesUsed! + 1;
       }
     });
     objectsToRemove.forEach((element) {
@@ -575,7 +588,8 @@ class WayfindingProvider extends ChangeNotifier {
     if (!repeatedDevice) {
       scannedObjects[scanResult.device.id.toString()]!.dwellTime =
           scannedObjects[scanResult.device.id.toString()]!.dwellTime! +
-              (_wayfindingConstantsModel.scanWaitTime !* 60); //account for seconds
+              (_wayfindingConstantsModel.scanWaitTime! *
+                  60); //account for seconds
       scannedObjects[scanResult.device.id.toString()]!.distance =
           getDistance(scanResult.rssi);
       if (scannedObjects[scanResult.device.id.toString()]!.dwellTime! >=
@@ -587,7 +601,8 @@ class WayfindingProvider extends ChangeNotifier {
         // eligibleType(
         //     scannedObjects[scanResult.device.id.toString()].deviceType)) {
         _wayfindingConstantsModel.qualifyingDevices =
-            _wayfindingConstantsModel.qualifyingDevices! + 1; // Add the # of unique devices detected
+            _wayfindingConstantsModel.qualifyingDevices! +
+                1; // Add the # of unique devices detected
       }
 
       // Log important information
@@ -831,8 +846,8 @@ class WayfindingProvider extends ChangeNotifier {
   /// permissionGranted = true
   /// forceOff (currently false)
   void startBluetooth(BuildContext context, bool permissionGranted) async {
-
-    if (PermissionStatus.granted != await _locationDataProvider!.locationObject.hasPermission()){
+    if (PermissionStatus.granted !=
+        await _locationDataProvider!.locationObject.hasPermission()) {
       advancedWayfindingEnabled = false;
       forceOff = true;
       notifyListeners();


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Adds hyphens where applicable to Scanned Advertisement ID. Closes #1213 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Fixes bug where scanned advertisement id has no hyphens.


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Ensure Scanned Advertisement ID matches following format when another UCSD App enabled device is nearby:
08506708-3068-0650-8008-0DA49DC3DD
