### PR TITLE
Package upgrade: firebase_crashlytics 2.0.4 --> 2.0.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Mobile app platform for campus.
 version: 1.0.0+1
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: "^2.2.1"
+  flutter: ^2.2.1
 dependencies:
   app_settings: 4.1.0
   barcode_widget: 2.0.1
@@ -15,7 +15,7 @@ dependencies:
   encrypt: 5.0.0
   firebase_analytics: 8.1.0
   firebase_core: 1.2.0
-  firebase_crashlytics: 2.0.4
+  firebase_crashlytics: 2.0.5
   firebase_messaging: 10.0.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Summary
Package upgrade: firebase_crashlytics 2.0.4 --> 2.0.5

## Changelog
[General] [Change] - Upgrade `firebase_crashlytics` from `2.0.4` to `2.0.5` ([changelog](https://pub.dev/packages/firebase_crashlytics/changelog))

## Test Plan
Regression test the following areas:
```
./lib/main.dart

```