### PR TITLE
Package upgrade: firebase_crashlytics 2.0.4 --> 2.2.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   encrypt: 5.0.0
   firebase_analytics: 8.1.0
   firebase_core: 1.2.0
-  firebase_crashlytics: 2.0.4
+  firebase_crashlytics: 2.2.1
   firebase_messaging: 10.0.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Summary
Package upgrade: firebase_crashlytics 2.0.4 --> 2.2.1

## Changelog
[General] [Change] - Upgrade `firebase_crashlytics` from `2.0.4` to `2.2.1` ([changelog](https://pub.dev/packages/firebase_crashlytics/changelog))

## Test Plan
Regression test the following areas:
```
./lib/ui/student_id/student_id_card.dart
./lib/ui/finals/finals_card.dart
./lib/ui/classes/classes_card.dart
./lib/main.dart

```