### PR TITLE
Notification toggle issue1181

### DIFF
--- a/lib/core/providers/notifications.dart
+++ b/lib/core/providers/notifications.dart
@@ -324,14 +324,14 @@ class PushNotificationDataProvider extends ChangeNotifier {
     } else {
       print('FCM: toggleNotificationsForTopic:subscribe: ' + topic!);
       _topicSubscriptionState[topic] = true;
-      _subscribeToTopics([topic]);
+      subscribeToTopics([topic]);
     }
     notifyListeners();
   }
 
   /// Iterates through passed in topics list
   /// Invokes [unsubscribeFromTopic] on firebase object [_fcm]
-  void _subscribeToTopics(List<String?> topics) {
+  void subscribeToTopics(List<String?> topics) {
     for (String? topic in topics) {
       if ((topic ?? "").isNotEmpty) {
         print('FCM: _subscribeToTopics: ' + topic!);

--- a/lib/core/providers/user.dart
+++ b/lib/core/providers/user.dart
@@ -320,7 +320,7 @@ class UserDataProvider extends ChangeNotifier {
           newModel.ucsdaffiliation = _authenticationModel!.ucsdaffiliation;
           newModel.pid = _authenticationModel!.pid;
           List<String> castSubscriptions = newModel.subscribedTopics!.cast<String>();
-          newModel.subscribedTopics = castSubscriptions;
+          newModel.subscribedTopics = castSubscriptions.toSet().toList();
           print('UserDataProvider:fetchUserProfile:newModel');
           print(newModel.toJson());
 
@@ -330,15 +330,11 @@ class UserDataProvider extends ChangeNotifier {
           if ((newModel.ucsdaffiliation ?? "").contains(studentPattern)) {
             newModel
               ..classifications =
-                  Classifications.fromJson({'student': true, 'staff': false})
-              ..subscribedTopics!
-                  .addAll(_pushNotificationDataProvider.studentTopics());
+                  Classifications.fromJson({'student': true, 'staff': false});
           } else if ((newModel.ucsdaffiliation ?? "").contains(staffPattern)) {
             newModel
               ..classifications =
-                  Classifications.fromJson({'staff': true, 'student': false})
-              ..subscribedTopics!
-                  .addAll(_pushNotificationDataProvider.staffTopics());
+                  Classifications.fromJson({'staff': true, 'student': false});
           } else {
             newModel.classifications =
                 Classifications.fromJson({'student': false, 'staff': false});

--- a/lib/core/providers/user.dart
+++ b/lib/core/providers/user.dart
@@ -6,6 +6,7 @@ import 'package:campus_mobile_experimental/core/models/user_profile.dart';
 import 'package:campus_mobile_experimental/core/providers/cards.dart';
 import 'package:campus_mobile_experimental/core/providers/notifications.dart';
 import 'package:campus_mobile_experimental/core/services/authentication.dart';
+import 'package:campus_mobile_experimental/core/services/notifications.dart';
 import 'package:campus_mobile_experimental/core/services/user.dart';
 import 'package:encrypt/encrypt.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -318,9 +319,8 @@ class UserDataProvider extends ChangeNotifier {
           newModel.username = await getUsernameFromDevice();
           newModel.ucsdaffiliation = _authenticationModel!.ucsdaffiliation;
           newModel.pid = _authenticationModel!.pid;
-          newModel.subscribedTopics =
-              _pushNotificationDataProvider.publicTopics();
-
+          List<String> castSubscriptions = newModel.subscribedTopics!.cast<String>();
+          newModel.subscribedTopics = castSubscriptions;
           print('UserDataProvider:fetchUserProfile:newModel');
           print(newModel.toJson());
 
@@ -344,6 +344,7 @@ class UserDataProvider extends ChangeNotifier {
                 Classifications.fromJson({'student': false, 'staff': false});
           }
           await updateUserProfileModel(newModel);
+          _pushNotificationDataProvider.subscribeToTopics(newModel.subscribedTopics!.cast<String>());
         }
       } else {
         _error = _userProfileService.error;


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
User's were being unsubscribed or subscribed to notifications they had not chose. In essence, the remote profile was not being reflected in app. Fixes #1181 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - The solution contained two portions. One was the removal of overrides that caused the public subscriptions to take precedent over the remote subscriptions. Second was the activation of all subscriptions in the remote profile to active.

## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->
Unsubscribe from one topic. Restart app and verify it is still unsubscribed.
Subscribe to topics. Restart app and verify all preferences were still observed.
Note* May take a couple seconds to propagate preferences from remote profile.
