### PR TITLE
Package upgrade: shared_preferences 2.0.6 --> 2.0.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   permission_handler: 7.1.0
   pointycastle: 3.3.4
   provider: 5.0.0
-  shared_preferences: 2.0.6
+  shared_preferences: 2.0.8
   uni_links2: 0.6.0+2
   url_launcher: 6.0.6
   uuid: 3.0.4


### PR DESCRIPTION
## Summary
Package upgrade: shared_preferences 2.0.6 --> 2.0.8

## Changelog
[General] [Change] - Upgrade `shared_preferences` from `2.0.6` to `2.0.8` ([changelog](https://pub.dev/packages/shared_preferences/changelog))

## Test Plan
Regression test the following areas:
```
./lib/ui/wayfinding/beacon_view.dart
./lib/ui/onboarding/onboarding_login.dart
./lib/ui/onboarding/onboarding_affiliations.dart
./lib/ui/home/home.dart
./lib/main.dart
./lib/core/providers/wayfinding.dart
./lib/core/providers/bluetooth.dart

```