### PR TITLE
Package upgrade: google_maps_flutter 2.0.6 --> 2.0.11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   flutter_secure_storage: 4.2.0
   flutter_sticky_header: 0.6.0
   get: 4.1.4
-  google_maps_flutter: 2.0.6
+  google_maps_flutter: 2.0.11
   hive: 2.0.4
   hive_flutter: 1.0.0
   intl: 0.17.0


### PR DESCRIPTION
## Summary
Package upgrade: google_maps_flutter 2.0.6 --> 2.0.11

## Changelog
[General] [Change] - Upgrade `google_maps_flutter` from `2.0.6` to `2.0.11` ([changelog](https://pub.dev/packages/google_maps_flutter/changelog))

## Test Plan
Regression test the following areas:
```
./lib/ui/map/my_location_button.dart
./lib/ui/map/map.dart
./lib/ui/map/directions_button.dart
./lib/core/providers/map.dart

```