### PR TITLE
Parking service v1.3 migration

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -79,7 +79,14 @@ class RouteTitles {
 }
 
 class ParkingDefaults {
-  static const defaultLots = ["P406", "P784", "P782", "P386", "P704", "P705"];
+  static const defaultLots = [
+    "406",
+    "784",
+    "P782",
+    "P386 (Gliderport)",
+    "P704",
+    "P705"
+  ];
   static const defaultSpots = ["S", "B", "A"];
 }
 

--- a/lib/core/services/parking.dart
+++ b/lib/core/services/parking.dart
@@ -17,7 +17,7 @@ class ParkingService {
   };
 
   final String campusParkingServiceApiUrl =
-      "https://api-qa.ucsd.edu:8243/campusparkingservice/1.0.0";
+      "https://api-qa.ucsd.edu:8243/campusparkingservice/v1.3";
 
   Future<bool> fetchParkingLotData() async {
     _error = null;
@@ -25,7 +25,7 @@ class ParkingService {
     try {
       /// fetch data
       String _response = await (_networkHelper.authorizedFetch(
-          campusParkingServiceApiUrl + "/parking/status", headers));
+          campusParkingServiceApiUrl + "/status", headers));
 
       /// parse data
       _data = parkingModelFromJson(_response);


### PR DESCRIPTION
## Summary
Migrate parking API to CampusParkingService v1.3


## Changelog
[General] [Change] - Update parking service endpoint to CampusParkingService v1.3
[General] [Change] - Fix default lot id's


## Test Plan
Regression test parking card features and functionality
User should see lots `406`, `784`, `P782`, `P386 (Gliderport)`, `P704`, `P705` by default

