### PR TITLE
Parking Neighborhoods v2 (#1533)

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -79,7 +79,14 @@ class RouteTitles {
 }
 
 class ParkingDefaults {
-  static const defaultLots = ["P406", "P784", "P782", "P386", "P704", "P705"];
+  static const defaultLots = [
+    "406",
+    "784",
+    "P782",
+    "P386 (Gliderport)",
+    "P704",
+    "P705"
+  ];
   static const defaultSpots = ["S", "B", "A"];
 }
 

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -193,22 +193,26 @@ class Router {
       case RoutePaths.ParkingLotsView:
         return MaterialPageRoute(builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return ParkingLotsView();
         });
       case RoutePaths.ParkingStructureView:
         return MaterialPageRoute(builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return ParkingStructureView();
         });
       case RoutePaths.NeighborhoodsView:
         return MaterialPageRoute(builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return NeighborhoodsView();
         });
       case RoutePaths.NeighborhoodsLotsView:
         List<String> data = settings.arguments as List<String>;
         return MaterialPageRoute(builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
+          Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return NeighborhoodLotsView(data);
         });
       case RoutePaths.SpotTypesView:

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -192,26 +192,22 @@ class Router {
         });
       case RoutePaths.ParkingLotsView:
         return MaterialPageRoute(builder: (_) {
-          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return ParkingLotsView();
         });
       case RoutePaths.ParkingStructureView:
         return MaterialPageRoute(builder: (_) {
-          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return ParkingStructureView();
         });
       case RoutePaths.NeighborhoodsView:
         return MaterialPageRoute(builder: (_) {
-          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return NeighborhoodsView();
         });
       case RoutePaths.NeighborhoodsLotsView:
         List<String> data = settings.arguments as List<String>;
         return MaterialPageRoute(builder: (_) {
-          Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return NeighborhoodLotsView(data);
         });

--- a/lib/core/providers/parking.dart
+++ b/lib/core/providers/parking.dart
@@ -221,9 +221,16 @@ class ParkingDataProvider extends ChangeNotifier {
 
   Map<String, List<String>> getParkingMap() {
     Map<String, List<String>> parkingMap = {};
+    List<String> neighborhoodsToSort = [];
     for (ParkingModel model in _parkingService.data!) {
+      neighborhoodsToSort.add(model.neighborhood!);
+    }
+    print(neighborhoodsToSort);
+    neighborhoodsToSort.sort();
+    print(neighborhoodsToSort);
+    for (String neighborhood in neighborhoodsToSort) {
       List<String> val = [];
-      parkingMap[model.neighborhood!] = val;
+      parkingMap[neighborhood] = val;
     }
 
     for (ParkingModel model in _parkingService.data!) {

--- a/lib/core/services/parking.dart
+++ b/lib/core/services/parking.dart
@@ -16,15 +16,16 @@ class ParkingService {
     "accept": "application/json",
   };
 
-  final String endpoint =
-      "https://api-qa.ucsd.edu:8243/parking/v1.2/status";
+  final String campusParkingServiceApiUrl =
+      "https://api-qa.ucsd.edu:8243/campusparkingservice/v1.3";
 
   Future<bool> fetchParkingLotData() async {
     _error = null;
     _isLoading = true;
     try {
       /// fetch data
-      String _response = await (_networkHelper.authorizedFetch(endpoint, headers));
+      String _response = await (_networkHelper.authorizedFetch(
+          campusParkingServiceApiUrl + "/status", headers));
 
       /// parse data
       _data = parkingModelFromJson(_response);
@@ -51,7 +52,7 @@ class ParkingService {
     final Map<String, String> tokenHeaders = {
       "content-type": 'application/x-www-form-urlencoded',
       "Authorization":
-      "Basic djJlNEpYa0NJUHZ5akFWT0VRXzRqZmZUdDkwYTp2emNBZGFzZWpmaWZiUDc2VUJjNDNNVDExclVh"
+          "Basic djJlNEpYa0NJUHZ5akFWT0VRXzRqZmZUdDkwYTp2emNBZGFzZWpmaWZiUDc2VUJjNDNNVDExclVh"
     };
     try {
       var response = await _networkHelper.authorizedPost(

--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -1,48 +1,102 @@
 import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_styles.dart';
+import 'package:campus_mobile_experimental/core/providers/bottom_nav.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class CMAppBar extends StatelessWidget {
   CMAppBar({
     this.title,
+    this.doneButton,
   });
+
   final String? title;
+  final bool? doneButton;
 
   @override
   Widget build(BuildContext context) {
-    return PreferredSize(
-      preferredSize: Size.fromHeight(42),
-      child: AppBar(
-        backgroundColor: ColorPrimary,
-        brightness: Brightness.dark,
-        primary: true,
-        centerTitle: true,
-        title: title == null
-            ? Image.asset(
-                'assets/images/UCSanDiegoLogo-nav.png',
-                fit: BoxFit.contain,
-                height: 28,
-              )
-            : Text(title!),
-      ),
-    );
+    if (doneButton == true) {
+      return PreferredSize(
+          preferredSize: Size.fromHeight(42),
+          child: AppBar(
+              backgroundColor: ColorPrimary,
+              brightness: Brightness.dark,
+              primary: true,
+              centerTitle: true,
+              title: title == null
+                  ? Image.asset(
+                      'assets/images/UCSanDiegoLogo-nav.png',
+                      fit: BoxFit.contain,
+                      height: 28,
+                    )
+                  : Text(title!),
+              actions: <Widget>[
+                Padding(
+                    padding: EdgeInsets.only(right: 20.0),
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        primary: Theme.of(context).buttonColor,
+                      ),
+                      child: Text(
+                        'Done',
+                      ),
+                      onPressed: () {
+                        // Set tab bar index to the Home tab
+                        Provider.of<BottomNavigationBarProvider>(context,
+                                listen: false)
+                            .currentIndex = NavigatorConstants.HomeTab;
+
+                        // Navigate to Home tab
+                        Navigator.of(context).pushNamedAndRemoveUntil(
+                            RoutePaths.BottomNavigationBar,
+                            (Route<dynamic> route) => false);
+
+                        // change the appBar title to the ucsd logo
+                        Provider.of<CustomAppBar>(context, listen: false)
+                            .changeTitle(CustomAppBar().appBar.title);
+                      },
+                    ))
+              ]));
+    } else {
+      return PreferredSize(
+        preferredSize: Size.fromHeight(42),
+        child: AppBar(
+          backgroundColor: ColorPrimary,
+          brightness: Brightness.dark,
+          primary: true,
+          centerTitle: true,
+          title: title == null
+              ? Image.asset(
+                  'assets/images/UCSanDiegoLogo-nav.png',
+                  fit: BoxFit.contain,
+                  height: 28,
+                )
+              : Text(title!),
+        ),
+      );
+    }
   }
 }
 
 class CustomAppBar extends ChangeNotifier {
   late CMAppBar appBar;
   String? title;
+  bool? doneButton;
+
   CustomAppBar() {
     makeAppBar();
   }
+
   makeAppBar() {
     appBar = CMAppBar(
       title: title,
+      doneButton: doneButton,
     );
   }
 
-  changeTitle(String? newTitle) {
+  changeTitle(String? newTitle, {done: false}) {
     title = RouteTitles.titleMap[newTitle];
+    doneButton = done;
     makeAppBar();
   }
 }

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -34,7 +34,7 @@ class CircularParkingIndicators extends StatelessWidget {
     Provider.of<ParkingDataProvider>(context)
         .spotTypesState!
         .forEach((key, value) {
-      if (value) {
+      if (value && selectedSpots.length < 4) {
         selectedSpots.add(key!);
       }
     });

--- a/lib/ui/parking/neighborhood_lot_view.dart
+++ b/lib/ui/parking/neighborhood_lot_view.dart
@@ -51,24 +51,21 @@ class _NeighborhoodLotsViewState extends State<NeighborhoodLotsView> {
     // loops through and adds buttons for the user to click on
     for (int i = 0; i < arguments.length; i++) {
       bool lotState = parkingDataProvider.parkingViewState![arguments[i]]!;
-      list.add(ListTile(
-        title: Padding(
-          padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
-          child: Text(
-            arguments[i],
-            style: TextStyle(
-                color: Theme.of(context)
-                    .colorScheme
-                    .secondary, // lotState ? colorFromHex('#006A96') : Theme.of(context).colorScheme.secondary,
-                fontSize: 20),
+      list.add(
+        ListTile(
+          title: Padding(
+            padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
+            child: Text(
+              arguments[i],
+              style: TextStyle(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .secondary, // lotState ? colorFromHex('#006A96') : Theme.of(context).colorScheme.secondary,
+                  fontSize: 20),
+            ),
           ),
-        ),
-        trailing: IconButton(
-          icon: Icon(lotState ? Icons.cancel_rounded : Icons.add_rounded),
-          color: Theme.of(context)
-              .colorScheme
-              .secondary, // lotState ? colorFromHex('#006A96') : Theme.of(context).colorScheme.secondary,
-          onPressed: () {
+          trailing: Icon(lotState ? Icons.cancel_rounded : Icons.add_rounded),
+          onTap: () {
             if (selectedLots == 10 && !lotState && showedScaffold != true) {
               ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                 content: Text(
@@ -80,7 +77,7 @@ class _NeighborhoodLotsViewState extends State<NeighborhoodLotsView> {
             parkingDataProvider.toggleLot(arguments[i], selectedLots);
           },
         ),
-      ));
+      );
     }
 
     // adds SizedBox to have a grey underline for the last item in the list

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -55,7 +55,25 @@ class _ParkingCardState extends State<ParkingCard> {
           selectedLotsViews.add(CircularParkingIndicators(model: model));
         }
       }
-
+      if (selectedLotsViews.isEmpty) {
+        return (Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              "No Lots to Display",
+              style: TextStyle(fontSize: 24),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 5),
+              child: Text(
+                "Add a Lot via 'Manage Lots'",
+                style: TextStyle(fontSize: 14),
+              ),
+            ),
+          ],
+        ));
+      }
       return Column(
         children: <Widget>[
           Expanded(

--- a/lib/ui/parking/parking_lot_view.dart
+++ b/lib/ui/parking/parking_lot_view.dart
@@ -47,24 +47,22 @@ class _ParkingLotViewState extends State<ParkingLotsView> {
     // loops through and adds buttons for the user to click on
     for (var i = 0; i < lots.length; i++) {
       bool lotViewState = parkingDataProvider.parkingViewState![lots[i]]!;
-      list.add(ListTile(
-        title: Padding(
-          padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
-          child: Text(
-            lots[i],
-            style: TextStyle(
-                color: Theme.of(context)
-                    .colorScheme
-                    .secondary, // lotViewState ? ColorPrimary : Colors.black,
-                fontSize: 20),
+      list.add(
+        ListTile(
+          title: Padding(
+            padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
+            child: Text(
+              lots[i],
+              style: TextStyle(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .secondary, // lotViewState ? ColorPrimary : Colors.black,
+                  fontSize: 20),
+            ),
           ),
-        ),
-        trailing: IconButton(
-          icon: Icon(lotViewState ? Icons.cancel_rounded : Icons.add_rounded),
-          color: Theme.of(context)
-              .colorScheme
-              .secondary, // lotViewState ? ColorPrimary : Colors.black,
-          onPressed: () {
+          trailing:
+              Icon(lotViewState ? Icons.cancel_rounded : Icons.add_rounded),
+          onTap: () {
             if (selectedLots == 10 && !lotViewState && showedScaffold != true) {
               ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                 content: Text(
@@ -76,7 +74,7 @@ class _ParkingLotViewState extends State<ParkingLotsView> {
             parkingDataProvider.toggleLot(lots[i], selectedLots);
           },
         ),
-      ));
+      );
     }
 
     // adds SizedBox to have a grey underline for the last item in the list

--- a/lib/ui/parking/parking_structure_view.dart
+++ b/lib/ui/parking/parking_structure_view.dart
@@ -50,24 +50,22 @@ class _ParkingStructureViewState extends State<ParkingStructureView> {
     for (var i = 0; i < structures.length; i++) {
       bool structureState =
           parkingDataProvider.parkingViewState![structures[i]]!;
-      list.add(ListTile(
-        title: Padding(
-          padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
-          child: Text(
-            structures[i],
-            style: TextStyle(
-                color: Theme.of(context)
-                    .colorScheme
-                    .secondary, // structureState ? ColorPrimary : Colors.black,
-                fontSize: 20),
+      list.add(
+        ListTile(
+          title: Padding(
+            padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
+            child: Text(
+              structures[i],
+              style: TextStyle(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .secondary, // structureState ? ColorPrimary : Colors.black,
+                  fontSize: 20),
+            ),
           ),
-        ),
-        trailing: IconButton(
-          icon: Icon(structureState ? Icons.cancel_rounded : Icons.add_rounded),
-          color: Theme.of(context)
-              .colorScheme
-              .secondary, // structureState ? ColorPrimary : Colors.black,
-          onPressed: () {
+          trailing:
+              Icon(structureState ? Icons.cancel_rounded : Icons.add_rounded),
+          onTap: () {
             if (selectedLots == 10 &&
                 !structureState &&
                 showedScaffold != true) {
@@ -81,7 +79,7 @@ class _ParkingStructureViewState extends State<ParkingStructureView> {
             parkingDataProvider.toggleLot(structures[i], selectedLots);
           },
         ),
-      ));
+      );
     }
 
     // adds SizedBox to have a grey underline for the last item in the list


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Parking card will not work until parking service is updated
- Fixed list tile buttons selection to be able to click anywhere on the tile, not just the icon
- Fixed out of order rendering for lots, now renders in alphabetical order
- Added a "no lots selected" view on main card when no lots are selected
- Limited spot types to >4 to prevent a bug where more than 3 are displayed
- Add a "Done" button to the top right nav on all selection pages so the user can go back to the home screen without tapping the back button 3 times.


NOTE: Another issue should be added to explore preserving scroll positions so the Done button does right to the parking card. 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Add] - Added message on card to to display when no lots are selected
[General] [Change] - Changed order of lots to display them alphabetically
[General] [Change] - Changed list tiles to be selectable instead of only the trailing icon
[General] [Add] - Added a "done" button by adding a field to the custom app bar class and related functions
[General] [Add] - added a restriction to rendering spot types, only render the first 3 on the list


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.



-->
Test extensively on iOS because I was only able to test on android.

- [ ] When there are no lots selected, the card displays a message prompting the user to add a lot.
- [ ] All lot screens should be in alphabetical order
- [ ] "Done" button to the top right nav on all selection pages so the user can go back to the home screen without tapping the back button 3 times. This should take you to the top of the home screen. Another issue should be added to explore preserving scroll positions. 
- [ ]  On the Manage Lots lot selection view, click anywhere on the row to activate or deactivate a lot.
- [ ]  Cant render more than 3 spot types

