### PR TITLE
Update endpoint in news.dart

### DIFF
--- a/lib/core/services/news.dart
+++ b/lib/core/services/news.dart
@@ -9,8 +9,12 @@ class NewsService {
   String? _error;
 
   final NetworkHelper _networkHelper = NetworkHelper();
+  final Map<String, String> headers = {
+    "accept": "application/json",
+  };
+
   final String endpoint =
-      'https://s3-us-west-2.amazonaws.com/ucsd-its-wts/now_ucsandiego/v1/allstories.json';
+      "https://api-qa.ucsd.edu:8243/qa/campusnews/v1/ucsdnewsaggregator";
 
   NewsModel _newsModels = NewsModel();
 
@@ -19,15 +23,42 @@ class NewsService {
     _isLoading = true;
     try {
       /// fetch data
-      String _response = await _networkHelper.fetchData(endpoint);
+      String _response =
+          await (_networkHelper.authorizedFetch(endpoint, headers));
 
       /// parse data
       _newsModels = newsModelFromJson(_response);
       _isLoading = false;
       return true;
     } catch (e) {
+      if (e.toString().contains("401")) {
+        if (await getNewToken()) {
+          return await fetchData();
+        }
+      }
+
       _error = e.toString();
       _isLoading = false;
+      return false;
+    }
+  }
+
+  Future<bool> getNewToken() async {
+    final String tokenEndpoint = "https://api-qa.ucsd.edu:8243/token";
+    final Map<String, String> tokenHeaders = {
+      "content-type": 'application/x-www-form-urlencoded',
+      "Authorization":
+          "Basic djJlNEpYa0NJUHZ5akFWT0VRXzRqZmZUdDkwYTp2emNBZGFzZWpmaWZiUDc2VUJjNDNNVDExclVh"
+    };
+    try {
+      var response = await _networkHelper.authorizedPost(
+          tokenEndpoint, tokenHeaders, "grant_type=client_credentials");
+
+      headers["Authorization"] = "Bearer " + response["access_token"];
+
+      return true;
+    } catch (e) {
+      _error = e.toString();
       return false;
     }
   }


### PR DESCRIPTION
## Summary
This incorporated the Athletics feed and changed the endpoint for news.dart to be an api-qa link. 


## Changelog
[General] [Change] - Added Athletics feed and changed endpoint.


## Test Plan
I tested on Iphone 8, Iphone 12 Pro, and Ipad Pro (12.9 inch). 
