### PR TITLE
Package upgrade: firebase_core 1.2.0 --> 1.8.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   dots_indicator: 2.0.0
   encrypt: 5.0.0
   firebase_analytics: 8.1.0
-  firebase_core: 1.2.0
+  firebase_core: 1.8.0
   firebase_crashlytics: 2.0.4
   firebase_messaging: 10.0.0
   flutter:


### PR DESCRIPTION
## Summary
Package upgrade: firebase_core 1.2.0 --> 1.8.0

## Changelog
[General] [Change] - Upgrade `firebase_core` from `1.2.0` to `1.8.0` ([changelog](https://pub.dev/packages/firebase_core/changelog))

## Test Plan
Regression test the following areas:
```
./lib/main.dart

```