### PR TITLE
Fixed Map Search Result Distances Formatting

### DIFF
--- a/lib/ui/map/more_results_list.dart
+++ b/lib/ui/map/more_results_list.dart
@@ -49,7 +49,7 @@ class MoreResultsList extends StatelessWidget {
                                           listen: false)
                                       .mapSearchModels[index]
                                       .distance!
-                                      .toStringAsPrecision(3) +
+                                      .toStringAsFixed(3) +
                                   ' mi'
                               : '--',
                           style: TextStyle(color: Colors.blue[600]),


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Fixes: https://github.com/UCSD/campus-mobile/issues/1663
Previously, the map search result distances were in scientific notation, which is hard to view.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Fixed map search result distances that were in scientific notiation


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

Pull the new updates, run the app, head over to the maps page, and search for Parking in the search bar, and click more results.

![image](https://user-images.githubusercontent.com/47834226/140667170-7bca99a7-cde8-4d0d-9150-9bfbc217ec90.png)
