### PR TITLE
Map search distance bug and precision change

### DIFF
--- a/lib/core/providers/map.dart
+++ b/lib/core/providers/map.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+
 import 'package:campus_mobile_experimental/core/models/location.dart';
 import 'package:campus_mobile_experimental/core/models/map.dart';
 import 'package:campus_mobile_experimental/core/services/map.dart';
@@ -120,7 +121,7 @@ class MapsDataProvider extends ChangeNotifier {
     double? latitude =
         _coordinates!.lat != null ? _coordinates!.lat : _defaultLat;
     double? longitude =
-        _coordinates!.lon != null ? _coordinates!.lat : _defaultLong;
+        _coordinates!.lon != null ? _coordinates!.lon : _defaultLong;
     if (_coordinates != null) {
       for (MapSearchModel model in _mapSearchModels) {
         if (model.mkrLat != null && model.mkrLong != null) {

--- a/lib/ui/map/more_results_list.dart
+++ b/lib/ui/map/more_results_list.dart
@@ -49,7 +49,7 @@ class MoreResultsList extends StatelessWidget {
                                           listen: false)
                                       .mapSearchModels[index]
                                       .distance!
-                                      .toStringAsFixed(3) +
+                                      .toStringAsFixed(1) +
                                   ' mi'
                               : '--',
                           style: TextStyle(color: Colors.blue[600]),


### PR DESCRIPTION
## Summary
- Built on PR #1680
- Fix a reference error causing map search distances to calculate incorrectly
- Change map search distance precision to tenths

## Changelog
[General] [Fix] - Fix a reference to search destination lat which should be lon
[General] [Fix] - Change to tenths precision for map search location distance

## Test Plan
Ensure map search distances are rendered with tenths precision
Ensure map search distances are accurate/expected to destinations
Regression test all map tab features and functionality

