### PR TITLE
Migrate news service to campusnews v1

### DIFF
--- a/lib/core/services/news.dart
+++ b/lib/core/services/news.dart
@@ -10,7 +10,7 @@ class NewsService {
 
   final NetworkHelper _networkHelper = NetworkHelper();
   final String endpoint =
-      'https://s3-us-west-2.amazonaws.com/ucsd-its-wts/now_ucsandiego/v1/allstories.json';
+      'https://dy6k9h2x5k.execute-api.us-west-2.amazonaws.com/qa/campusnews/v1/ucsdnewsaggregator';
 
   NewsModel _newsModels = NewsModel();
 


### PR DESCRIPTION
## Summary
News service migration to campusnews v1
Resolves issues in #1650


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Change] - Added Athletics feed articles to campusnews v1
[General] [Change] - MIgrate news service to campusnews v1

## Test Plan
Test all news card features and functionality

