### PR TITLE
Save Page Scroll Position

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -47,82 +47,82 @@ class Router {
   static Route<dynamic> generateRoute(RouteSettings settings) {
     switch (settings.name) {
       case RoutePaths.BottomNavigationBar:
-        return MaterialPageRoute(builder: (_) => BottomTabBar());
+        return MaterialPageRoute(settings: settings, builder: (_) => BottomTabBar());
       case RoutePaths.OnboardingInitial:
-        return MaterialPageRoute(builder: (_) => OnboardingInitial());
+        return MaterialPageRoute(settings: settings, builder: (_) => OnboardingInitial());
       case RoutePaths.Onboarding:
-        return MaterialPageRoute(builder: (_) => OnboardingScreen());
+        return MaterialPageRoute(settings: settings, builder: (_) => OnboardingScreen());
       case RoutePaths.OnboardingAffiliations:
-        return MaterialPageRoute(builder: (_) => OnboardingAffiliations());
+        return MaterialPageRoute(settings: settings, builder: (_) => OnboardingAffiliations());
       case RoutePaths.OnboardingLogin:
-        return MaterialPageRoute(builder: (_) => OnboardingLogin());
+        return MaterialPageRoute(settings: settings, builder: (_) => OnboardingLogin());
       case RoutePaths.Home:
-        return MaterialPageRoute(builder: (_) => Home());
+        return MaterialPageRoute(settings: settings, builder: (_) => Home());
       case RoutePaths.Map:
-        return MaterialPageRoute(builder: (_) => prefix0.Maps());
+        return MaterialPageRoute(settings: settings, builder: (_) => prefix0.Maps());
       case RoutePaths.MapSearch:
-        return MaterialPageRoute(builder: (_) => MapSearchView());
+        return MaterialPageRoute(settings: settings, builder: (_) => MapSearchView());
       case RoutePaths.Notifications:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return NotificationsListView();
         });
       case RoutePaths.Profile:
-        return MaterialPageRoute(builder: (_) => Profile());
+        return MaterialPageRoute(settings: settings, builder: (_) => Profile());
       case RoutePaths.NewsViewAll:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return NewsList();
         });
       case RoutePaths.EventsViewAll:
-        return MaterialPageRoute(builder: (context) {
+        return MaterialPageRoute(settings: settings, builder: (context) {
           Provider.of<CustomAppBar>(context).changeTitle(settings.name);
           return EventsList();
         });
       case RoutePaths.NewsDetailView:
         Item newsItem = settings.arguments as Item;
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return NewsDetailView(data: newsItem);
         });
       case RoutePaths.EventDetailView:
         EventModel data = settings.arguments as EventModel;
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return EventDetailView(data: data);
         });
       case RoutePaths.ManageAvailabilityView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return ManageAvailabilityView();
         });
       case RoutePaths.VentilationBuildings:
         List<VentilationLocationsModel> data =
             settings.arguments as List<VentilationLocationsModel>;
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return VentilationBuildings(data);
         });
       case RoutePaths.VentilationFloors:
         List<BuildingFloor> data = settings.arguments as List<BuildingFloor>;
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return VentilationFloors(data);
         });
       case RoutePaths.VentilationRooms:
         List<String> data = settings.arguments as List<String>;
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return VentilationRooms(data);
         });
       case RoutePaths.DiningViewAll:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return DiningList();
         });
       case RoutePaths.DiningDetailView:
         DiningModel data = settings.arguments as DiningModel;
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return DiningDetailView(data: data);
         });
@@ -133,83 +133,83 @@ class Router {
         String? disclaimer = arguments['disclaimer'] as String?;
         String? disclaimerEmail = arguments['disclaimerEmail'] as String?;
         return MaterialPageRoute(
-            builder: (_) => NutritionFactsView(
+            settings: settings, builder: (_) => NutritionFactsView(
                   data: data,
                   disclaimer: disclaimer,
                   disclaimerEmail: disclaimerEmail,
                 ));
       case RoutePaths.ManageParkingView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return ManageParkingView();
         });
       case RoutePaths.SpotTypesView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return SpotTypesView();
         });
       case RoutePaths.CardsView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return CardsView();
         });
       case RoutePaths.NotificationsSettingsView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return NotificationsSettingsView();
         });
       case RoutePaths.BluetoothPermissionsView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return AdvancedWayfindingPermission();
         });
       case RoutePaths.AutomaticBluetoothLoggerView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return AutomaticBluetoothLoggerView();
         });
       case RoutePaths.ClassScheduleViewAll:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return ClassList();
         });
       case RoutePaths.ManageParkingView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return ManageParkingView();
         });
       case RoutePaths.ParkingLotsView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return ParkingLotsView();
         });
       case RoutePaths.ParkingStructureView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return ParkingStructureView();
         });
       case RoutePaths.NeighborhoodsView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return NeighborhoodsView();
         });
       case RoutePaths.NeighborhoodsLotsView:
         List<String> data = settings.arguments as List<String>;
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name, done: true);
           return NeighborhoodLotsView(data);
         });
       case RoutePaths.SpotTypesView:
-        return MaterialPageRoute(builder: (_) {
+        return MaterialPageRoute(settings: settings, builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return SpotTypesView();
         });
       case RoutePaths.BeaconView:
-        return MaterialPageRoute(builder: (_) => BeaconView());
+        return MaterialPageRoute(settings: settings, builder: (_) => BeaconView());
       case RoutePaths.ScanditScanner:
-        return MaterialPageRoute(builder: (_) => ScanditScanner());
+        return MaterialPageRoute(settings: settings, builder: (_) => ScanditScanner());
       default:
-        return MaterialPageRoute(builder: (_) => Home());
+        return MaterialPageRoute(settings: settings, builder: (_) => Home());
     }
   }
 }

--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -94,6 +94,7 @@ class _HomeState extends State<Home> {
         padding: EdgeInsets.only(
             top: cardMargin + 2.0, right: 0.0, bottom: 0.0, left: 0.0),
         children: createList(context),
+        key: PageStorageKey<String>('homePage'),
       ),
     );
   }

--- a/lib/ui/navigator/bottom.dart
+++ b/lib/ui/navigator/bottom.dart
@@ -29,7 +29,16 @@ class _BottomTabBarState extends State<BottomTabBar> {
       appBar: PreferredSize(
           preferredSize: Size.fromHeight(42),
           child: Provider.of<CustomAppBar>(context).appBar),
-      body: PushNotificationWrapper(child: currentTab[provider.currentIndex]),
+      body: IndexedStack(
+        children: [
+          PushNotificationWrapper(child: Home()),
+          PushNotificationWrapper(child: prefix0.Maps()),
+          PushNotificationWrapper(child: NotificationsListView()),
+          PushNotificationWrapper(child: Profile()),
+        ],
+
+        index: provider.currentIndex,
+      ),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
         currentIndex: provider.currentIndex,

--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -47,9 +47,8 @@ class CMAppBar extends StatelessWidget {
                             .currentIndex = NavigatorConstants.HomeTab;
 
                         // Navigate to Home tab
-                        Navigator.of(context).pushNamedAndRemoveUntil(
-                            RoutePaths.BottomNavigationBar,
-                            (Route<dynamic> route) => false);
+                        Navigator.pop(context);
+                        Navigator.pop(context);
 
                         // change the appBar title to the ucsd logo
                         Provider.of<CustomAppBar>(context, listen: false)

--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -47,8 +47,12 @@ class CMAppBar extends StatelessWidget {
                             .currentIndex = NavigatorConstants.HomeTab;
 
                         // Navigate to Home tab
-                        Navigator.pop(context);
-                        Navigator.pop(context);
+                        Navigator.popUntil(context, (route) {
+                          if (route.settings.name != 'bottom_navigation_bar') {
+                            return false;
+                          }
+                          return true;
+                        });
 
                         // change the appBar title to the ucsd logo
                         Provider.of<CustomAppBar>(context, listen: false)


### PR DESCRIPTION
## Summary
Should be a final working fix for issue #1651 where page position is not saved between pages. 

We previously assumed page to be a list of widgets, and thus tried to use PageStorageKey. When in fact the page body is dynamically fetched from a list using an index from a data provider.

Thus fix was to use an IndexedStack, with the index set to the persisted index from the data provider.


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Page scroll position is saved when switching between tabs.


## Test Plan
1. Scroll down halfway on the home page.
2. Navigate to another page (Maps, Notifications, etc.)
3. Navigate back to home page, and ensure that scroll position was saved.
4. Repeat multiple times to ensure fix is consistently working.

https://user-images.githubusercontent.com/47834226/155422712-2f2e0cfa-6f20-4a07-86ec-73f481baf5bb.mp4


