### PR TITLE
1798: Surround both image and text of EventTile in InkWell

### DIFF
--- a/lib/ui/events/event_tile.dart
+++ b/lib/ui/events/event_tile.dart
@@ -9,6 +9,7 @@ class EventTile extends StatelessWidget {
   const EventTile({Key? key, required this.data}) : super(key: key);
   final EventModel data;
   final double tileWidth = 190;
+
   @override
   Widget build(BuildContext context) {
     return Provider.of<EventsDataProvider>(context).isLoading!
@@ -23,15 +24,15 @@ class EventTile extends StatelessWidget {
       width: tileWidth,
       height: 300,
       margin: EdgeInsets.zero,
-      child: Column(
-        children: [
-          eventImageLoader(data.imageThumb),
-          InkWell(
-            onTap: () {
-              Navigator.pushNamed(context, RoutePaths.EventDetailView,
-                  arguments: data);
-            },
-            child: SizedBox(
+      child: InkWell(
+        onTap: () {
+          Navigator.pushNamed(context, RoutePaths.EventDetailView,
+              arguments: data);
+        },
+        child: Column(
+          children: [
+            eventImageLoader(data.imageThumb),
+            SizedBox(
               height: 145,
               width: tileWidth,
               child: DecoratedBox(
@@ -66,8 +67,8 @@ class EventTile extends StatelessWidget {
                 ),
               ),
             ),
-          ),
-        ],
+          ], // children
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
1798: Image in EventTile not linked to event detail. Fix so both image and text linked.

## Changelog
[General] [Add] - Add links from events card images to event details

## Test Plan
1. Click on image of EventTile.
2. Click on text of EventTile.

https://user-images.githubusercontent.com/9058232/176971823-5414bc72-43ab-4cb1-9901-296322ab9be6.mp4


