### PR TITLE
Change Availability to Busyness

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -71,7 +71,7 @@ class RouteTitles {
     'dining/dining_list_view': 'Dining',
     'dining/dining_detail_view': 'Dining',
     'dining/dining_nutrition_view': 'Dining',
-    'availability/detailed_view': 'Availability'
+    'availability/detailed_view': 'Busyness'
   };
 }
 
@@ -181,7 +181,7 @@ class CardTitleConstants {
     'schedule': 'Classes',
     'shuttle': "Shuttle",
     'dining': 'Dining',
-    'availability': 'Availability',
+    'availability': 'Busyness',
     'events': 'Events',
     'news': 'News',
     'parking': 'Parking',

--- a/lib/core/services/cards.dart
+++ b/lib/core/services/cards.dart
@@ -24,7 +24,7 @@ class CardsService {
     /// API Manager Service
     try {
       String cardListEndpoint =
-          "https://api-qa.ucsd.edu:8243/mobilecardsservice/v1.0.0/mobilecardslist?version=8&ucsdaffiliation=" +
+          "https://api-qa.ucsd.edu:8243/mobilecardsservice/v1.0.0/mobilecardslist?version=9&ucsdaffiliation=" +
               ucsdAffiliation;
       String _response =
           await _networkHelper.authorizedFetch(cardListEndpoint, headers);

--- a/lib/ui/availability/availability_detail_view.dart
+++ b/lib/ui/availability/availability_detail_view.dart
@@ -1,6 +1,6 @@
 import 'package:campus_mobile_experimental/core/models/availability.dart';
-import 'package:campus_mobile_experimental/ui/common/container_view.dart';
 import 'package:campus_mobile_experimental/ui/availability/availability_constants.dart';
+import 'package:campus_mobile_experimental/ui/common/container_view.dart';
 import 'package:flutter/material.dart';
 
 class AvailabilityDetailedView extends StatelessWidget {
@@ -44,7 +44,7 @@ class AvailabilityDetailedView extends StatelessWidget {
                   alignment: Alignment.centerLeft,
                   child: Text(
                     (100 * percentAvailability(floor)).toInt().toString() +
-                        '% Availability',
+                        '% Busy',
                     // style: TextStyle(color: Colors.black),
                   )),
               Align(
@@ -79,15 +79,15 @@ class AvailabilityDetailedView extends StatelessWidget {
 
   // Calculate the percent available
   num percentAvailability(Floor subLocationFloor) =>
-      1 - subLocationFloor.percentage!;
+      subLocationFloor.percentage!;
 
   // Color options
   setIndicatorColor(num percentage) {
     if (percentage >= .75)
-      return Colors.green;
+      return Colors.red;
     else if (percentage >= .25)
       return Colors.yellow;
     else
-      return Colors.red;
+      return Colors.green;
   }
 }

--- a/lib/ui/availability/availability_display.dart
+++ b/lib/ui/availability/availability_display.dart
@@ -1,6 +1,6 @@
+import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/core/models/availability.dart';
 import 'package:campus_mobile_experimental/ui/availability/availability_constants.dart';
-import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:flutter/material.dart';
 
 class AvailabilityDisplay extends StatelessWidget {
@@ -70,7 +70,7 @@ class AvailabilityDisplay extends StatelessWidget {
                       (100 * percentAvailability(subLocation))
                               .toInt()
                               .toString() +
-                          '% Availability',
+                          '% Busy',
                       // style: TextStyle(color: Colors.black),
                     )),
                 Align(
@@ -124,14 +124,14 @@ class AvailabilityDisplay extends StatelessWidget {
     );
   }
 
-  num percentAvailability(SubLocations location) => 1 - location.percentage!;
+  num percentAvailability(SubLocations location) => location.percentage!;
 
   setIndicatorColor(num percentage) {
     if (percentage >= .75)
-      return Colors.green;
+      return Colors.red;
     else if (percentage >= .25)
       return Colors.yellow;
     else
-      return Colors.red;
+      return Colors.green;
   }
 }

--- a/lib/ui/common/card_container.dart
+++ b/lib/ui/common/card_container.dart
@@ -118,7 +118,7 @@ class CardContainer extends StatelessWidget {
               )),
         ),
       );
-    } else if (titleText == "Availability") {
+    } else if (titleText == "Busyness") {
       // web cards are still sized with static values
       return Container(
         width: double.infinity,


### PR DESCRIPTION
## Summary
Change Availability card to Busyness


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Change] - Availability references changed to Busyness
[General] [Change] - Availability bar colors and percentages inverted
[General] [Change] - Migrate to mobile cards service v9


