### PR TITLE
change deprecated buttonColor with background color

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -300,7 +300,7 @@ SPEC CHECKSUMS:
   location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
-  path_provider_ios: 7d7ce634493af4477d156294792024ec3485acd5
+  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Protobuf: adb85cd18a15bd1a777c158af9fd6e612a0e6d69

--- a/lib/core/providers/connectivity.dart
+++ b/lib/core/providers/connectivity.dart
@@ -53,7 +53,8 @@ class InternetConnectivityProvider extends ChangeNotifier {
           onPressed: () => Navigator.pop(context, 'Ok'),
           child: Text('Ok'),
           style: TextButton.styleFrom(
-            primary: Theme.of(context).buttonColor,
+            // primary: Theme.of(context).buttonColor,
+            primary: Theme.of(context).backgroundColor,
           ),
         ),
       ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,7 +77,8 @@ class CampusMobile extends StatelessWidget {
       primarySwatch: ColorPrimary,
       primaryColor: lightPrimaryColor,
       brightness: Brightness.light,
-      buttonColor: lightButtonColor,
+      // buttonColor: lightButtonColor,
+      backgroundColor: lightButtonColor, // added
       textTheme: lightThemeText,
       iconTheme: lightIconTheme,
       appBarTheme: lightAppBarTheme,
@@ -87,7 +88,8 @@ class CampusMobile extends StatelessWidget {
       primarySwatch: ColorPrimary,
       primaryColor: darkPrimaryColor,
       brightness: Brightness.dark,
-      buttonColor: darkButtonColor,
+      // buttonColor: darkButtonColor,
+      backgroundColor: darkButtonColor, // added
       textTheme: darkThemeText,
       iconTheme: darkIconTheme,
       appBarTheme: darkAppBarTheme,

--- a/lib/ui/availability/availability_card.dart
+++ b/lib/ui/availability/availability_card.dart
@@ -80,7 +80,8 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'Manage Locations',

--- a/lib/ui/availability/manage_availability_view.dart
+++ b/lib/ui/availability/manage_availability_view.dart
@@ -60,7 +60,8 @@ class _ManageAvailabilityViewState extends State<ManageAvailabilityView> {
           trailing: Switch(
             value: Provider.of<AvailabilityDataProvider>(context)
                 .locationViewState[model.locationName]!,
-            activeColor: Theme.of(context).buttonColor,
+            // activeColor: Theme.of(context).buttonColor,
+            activeColor: Theme.of(context).backgroundColor,
             onChanged: (_) {
               _availabilityDataProvider.toggleLocation(model.locationName);
             },

--- a/lib/ui/classes/classes_card.dart
+++ b/lib/ui/classes/classes_card.dart
@@ -18,7 +18,8 @@ class ClassScheduleCard extends StatelessWidget {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'View All',

--- a/lib/ui/dining/dining_card.dart
+++ b/lib/ui/dining/dining_card.dart
@@ -44,7 +44,8 @@ class DiningCard extends StatelessWidget {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'View All',

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -56,7 +56,8 @@ class DiningDetailView extends StatelessWidget {
         model.coordinates!.lon != null) {
       return TextButton(
         style: TextButton.styleFrom(
-          primary: Theme.of(context).buttonColor,
+          // primary: Theme.of(context).buttonColor,
+          primary: Theme.of(context).backgroundColor,
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -100,7 +101,8 @@ class DiningDetailView extends StatelessWidget {
       return ElevatedButton(
         style: ElevatedButton.styleFrom(
           onPrimary: Theme.of(context).primaryColor, // foreground
-          primary: Theme.of(context).buttonColor,
+          // primary: Theme.of(context).buttonColor,
+          primary: Theme.of(context).backgroundColor,
         ),
         child: Text('Visit Website',
             style: TextStyle(
@@ -127,7 +129,8 @@ class DiningDetailView extends StatelessWidget {
             )),
         style: ElevatedButton.styleFrom(
           onPrimary: Theme.of(context).primaryColor, // foreground
-          primary: Theme.of(context).buttonColor,
+          // primary: Theme.of(context).buttonColor,
+          primary: Theme.of(context).backgroundColor,
         ),
         onPressed: () {
           try {

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -152,7 +152,8 @@ class DiningList extends StatelessWidget {
   Widget buildIconWithDistance(DiningModel data, BuildContext context) {
     return TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       onPressed: () {
         try {

--- a/lib/ui/dining/dining_menu_list.dart
+++ b/lib/ui/dining/dining_menu_list.dart
@@ -66,7 +66,8 @@ class _DiningMenuListState extends State<DiningMenuList> {
                   TextSpan(
                     text: item.name,
                     style: TextStyle(
-                      color: Theme.of(context).buttonColor,
+                      // color: Theme.of(context).buttonColor,
+                      color: Theme.of(context).backgroundColor,
                       fontSize: 18,
                     ),
                   ),
@@ -133,7 +134,8 @@ class _DiningMenuListState extends State<DiningMenuList> {
         isSelected: Provider.of<DiningDataProvider>(context).filtersSelected,
         textStyle: TextStyle(fontSize: 18),
         selectedColor: Theme.of(context).textTheme.button!.color,
-        fillColor: Theme.of(context).buttonColor,
+        // fillColor: Theme.of(context).buttonColor,
+        fillColor: Theme.of(context).backgroundColor,
         borderRadius: BorderRadius.circular(10),
         constraints: BoxConstraints.expand(
             width: (MediaQuery.of(context).size.width - 40) * .33, height: 38),
@@ -214,7 +216,8 @@ class LabeledRadio extends StatelessWidget {
             value: value,
             groupValue: groupValue,
             onChanged: onChanged,
-            activeColor: Theme.of(context).buttonColor,
+            // activeColor: Theme.of(context).buttonColor,
+            activeColor: Theme.of(context).backgroundColor,
           ),
           Container(
             child: Text(

--- a/lib/ui/events/events_card.dart
+++ b/lib/ui/events/events_card.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 const String cardId = 'events';
+
 //edit these files
 class EventsCard extends StatelessWidget {
   Widget buildEventsCard(List<EventModel>? data) {
@@ -19,7 +20,8 @@ class EventsCard extends StatelessWidget {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'View All',

--- a/lib/ui/events/events_detail_view.dart
+++ b/lib/ui/events/events_detail_view.dart
@@ -107,7 +107,8 @@ class LearnMoreButton extends StatelessWidget {
       child: ElevatedButton(
           style: ElevatedButton.styleFrom(
             onPrimary: Theme.of(context).primaryColor, // foreground
-            primary: Theme.of(context).buttonColor,
+            // primary: Theme.of(context).buttonColor,
+            primary: Theme.of(context).backgroundColor,
           ),
           child: Text(
             'Learn More',

--- a/lib/ui/map/more_results_list.dart
+++ b/lib/ui/map/more_results_list.dart
@@ -68,7 +68,8 @@ class MoreResultsList extends StatelessWidget {
           );
         },
         style: ElevatedButton.styleFrom(
-          primary: Theme.of(context).buttonColor,
+          // primary: Theme.of(context).buttonColor,
+          primary: Theme.of(context).backgroundColor,
         ),
         child: Text(
           'Show More Results',

--- a/lib/ui/my_chart/my_chart_card.dart
+++ b/lib/ui/my_chart/my_chart_card.dart
@@ -58,7 +58,8 @@ class MyStudentChartCard extends StatelessWidget {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'Log in to MyStudentChart',

--- a/lib/ui/mystudentchart/mystudentchart.dart
+++ b/lib/ui/mystudentchart/mystudentchart.dart
@@ -58,7 +58,8 @@ class MyStudentChartCard extends StatelessWidget {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'Log in to MyStudentChart',

--- a/lib/ui/myucsdchart/myucsdchart.dart
+++ b/lib/ui/myucsdchart/myucsdchart.dart
@@ -58,7 +58,8 @@ class MyUCSDChartCard extends StatelessWidget {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'Log in to MyUCSDChart',

--- a/lib/ui/news/news_card.dart
+++ b/lib/ui/news/news_card.dart
@@ -31,7 +31,8 @@ class NewsCard extends StatelessWidget {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'View All',

--- a/lib/ui/news/news_detail_view.dart
+++ b/lib/ui/news/news_detail_view.dart
@@ -64,7 +64,8 @@ class ContinueReadingButton extends StatelessWidget {
         child: ElevatedButton(
           style: ElevatedButton.styleFrom(
             onPrimary: Theme.of(context).primaryColor, // foreground
-            primary: Theme.of(context).buttonColor,
+            // primary: Theme.of(context).buttonColor,
+            primary: Theme.of(context).backgroundColor,
           ),
           onPressed: () async {
             try {

--- a/lib/ui/onboarding/onboarding_login.dart
+++ b/lib/ui/onboarding/onboarding_login.dart
@@ -255,7 +255,8 @@ class _OnboardingLoginState extends State<OnboardingLogin> {
     // set up the button
     Widget okButton = TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text("OK"),
       onPressed: () {

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -109,7 +109,8 @@ class _ParkingCardState extends State<ParkingCard> {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'Manage Lots',
@@ -120,7 +121,8 @@ class _ParkingCardState extends State<ParkingCard> {
     ));
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'Manage Spots',

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -62,7 +62,8 @@ class _SpotTypesViewState extends State<SpotTypesView> {
             spotTypesDataProvider.toggleSpotSelection(
                 data.spotKey, selectedSpots);
           },
-          activeColor: Theme.of(context).buttonColor,
+          // activeColor: Theme.of(context).buttonColor,
+          activeColor: Theme.of(context).backgroundColor,
         ),
       ));
     }

--- a/lib/ui/profile/cards.dart
+++ b/lib/ui/profile/cards.dart
@@ -31,19 +31,23 @@ class _CardsViewState extends State<CardsView> {
       onReorder: _onReorder,
     );
 
-    if( _cardsDataProvider!.noInternet! ) {
-      Future.delayed(Duration.zero, () => {
-        showDialog(context: context, builder: (BuildContext ctx) => AlertDialog(
-            title: const Text('No Internet'),
-            content: const Text('Cards requires an internet connection.'),
-            actions: <Widget>[
-              TextButton(
-                onPressed: () => Navigator.pop(context, 'Ok'),
-                child: const Text('Ok'),
-              ),
-            ]
-        ))
-      });
+    if (_cardsDataProvider!.noInternet!) {
+      Future.delayed(
+          Duration.zero,
+          () => {
+                showDialog(
+                    context: context,
+                    builder: (BuildContext ctx) => AlertDialog(
+                            title: const Text('No Internet'),
+                            content: const Text(
+                                'Cards requires an internet connection.'),
+                            actions: <Widget>[
+                              TextButton(
+                                onPressed: () => Navigator.pop(context, 'Ok'),
+                                child: const Text('Ok'),
+                              ),
+                            ]))
+              });
     }
 
     return tempView;
@@ -85,17 +89,15 @@ class _CardsViewState extends State<CardsView> {
             onChanged: (_) {
               _cardsDataProvider!.toggleCard(card);
             },
-            activeColor: Theme.of(context).buttonColor,
+            // activeColor: Theme.of(context).buttonColor,
+            activeColor: Theme.of(context).backgroundColor,
           ),
         ));
-      }
-      catch (e) {
+      } catch (e) {
         FirebaseCrashlytics.instance.log('error getting $card in profile');
         FirebaseCrashlytics.instance.recordError(
             e, StackTrace.fromString(e.toString()),
-            reason: "Profile/Cards: Failed to load Cards page",
-            fatal: false
-        );
+            reason: "Profile/Cards: Failed to load Cards page", fatal: false);
 
         _cardsDataProvider!.changeInternetStatus(true);
       }

--- a/lib/ui/profile/login.dart
+++ b/lib/ui/profile/login.dart
@@ -73,7 +73,8 @@ class _LoginState extends State<Login> {
       ),
       trailing: OutlinedButton(
         style: OutlinedButton.styleFrom(
-          primary: Theme.of(context).buttonColor,
+          // primary: Theme.of(context).buttonColor,
+          primary: Theme.of(context).backgroundColor,
         ),
         child: Text('Log out'),
         onPressed: () => executeLogout(),
@@ -152,7 +153,8 @@ class _LoginState extends State<Login> {
                 Expanded(
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      primary: Theme.of(context).buttonColor,
+                      // primary: Theme.of(context).buttonColor,
+                      primary: Theme.of(context).backgroundColor,
                     ),
                     child: Text(
                       'Sign In',
@@ -214,7 +216,8 @@ class _LoginState extends State<Login> {
     // set up the button
     Widget okButton = TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text("OK"),
       onPressed: () {

--- a/lib/ui/profile/notifications.dart
+++ b/lib/ui/profile/notifications.dart
@@ -33,7 +33,8 @@ class NotificationsSettingsView extends StatelessWidget {
             Provider.of<UserDataProvider>(context, listen: false)
                 .toggleNotifications(topic);
           },
-          activeColor: Theme.of(context).buttonColor,
+          // activeColor: Theme.of(context).buttonColor,
+          activeColor: Theme.of(context).backgroundColor,
         ),
       ));
     }

--- a/lib/ui/scanner/native_scanner_card.dart
+++ b/lib/ui/scanner/native_scanner_card.dart
@@ -68,7 +68,8 @@ class NativeScannerCard extends StatelessWidget {
   Widget buildActionButton(BuildContext context) {
     return TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         getActionButtonText(context),

--- a/lib/ui/scanner/native_scanner_view.dart
+++ b/lib/ui/scanner/native_scanner_view.dart
@@ -145,7 +145,8 @@ class _ScanditScannerState extends State<ScanditScanner> {
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
                     padding: EdgeInsets.only(left: 32.0, right: 32.0),
-                    primary: Theme.of(context).buttonColor,
+                    // primary: Theme.of(context).buttonColor,
+                    primary: Theme.of(context).backgroundColor,
                   ),
                   onPressed: () {
                     _scannerDataProvider.setDefaultStates();

--- a/lib/ui/shuttle/shuttle_card.dart
+++ b/lib/ui/shuttle/shuttle_card.dart
@@ -114,7 +114,8 @@ class _ShuttleCardState extends State<ShuttleCard> {
     List<Widget> actionButtons = [];
     actionButtons.add(TextButton(
       style: TextButton.styleFrom(
-        primary: Theme.of(context).buttonColor,
+        // primary: Theme.of(context).buttonColor,
+        primary: Theme.of(context).backgroundColor,
       ),
       child: Text(
         'Manage Shuttle Stops',

--- a/lib/ui/wayfinding/wayfinding_permissions.dart
+++ b/lib/ui/wayfinding/wayfinding_permissions.dart
@@ -126,7 +126,8 @@ class _AdvancedWayfindingPermissionState
                                 _wayfindingProvider.setAWPreference();
                               });
                             },
-                            activeColor: Theme.of(context).buttonColor,
+                            // activeColor: Theme.of(context).buttonColor,
+                            activeColor: Theme.of(context).backgroundColor,
                           );
                         } else {
                           return CircularProgressIndicator(

--- a/lib/ui/wifi/wifi_card.dart
+++ b/lib/ui/wifi/wifi_card.dart
@@ -256,7 +256,9 @@ class _WiFiCardState extends State<WiFiCard>
                               TextButton(
                                   child: Text("Dismiss"),
                                   style: TextButton.styleFrom(
-                                      primary: Theme.of(context).buttonColor),
+                                    // primary: Theme.of(context).buttonColor,
+                                    primary: Theme.of(context).backgroundColor,
+                                  ),
                                   onPressed: () {
                                     Navigator.of(context).pop();
                                   })
@@ -344,7 +346,10 @@ class _WiFiCardState extends State<WiFiCard>
                                 TextButton(
                                     child: Text("Dismiss"),
                                     style: TextButton.styleFrom(
-                                        primary: Theme.of(context).buttonColor),
+                                      // primary: Theme.of(context).buttonColor
+                                      primary:
+                                          Theme.of(context).backgroundColor,
+                                    ),
                                     onPressed: () {
                                       Navigator.of(context).pop();
                                       _buttonEnabled = false;
@@ -455,7 +460,10 @@ class _WiFiCardState extends State<WiFiCard>
                                 TextButton(
                                     child: Text("Dismiss"),
                                     style: TextButton.styleFrom(
-                                        primary: Theme.of(context).buttonColor),
+                                      // primary: Theme.of(context).buttonColor,
+                                      primary:
+                                          Theme.of(context).backgroundColor,
+                                    ),
                                     onPressed: () {
                                       Navigator.of(context).pop();
                                       _buttonEnabled = false;


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
I get rid of the deprecated buttonColor property but keep the original function through adding background color in the theme

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[CATEGORY] [TYPE] - Message
[General][Change] The buttonColor property of theme is deprecated for current version of flutter. We need to get rid of it but still maintain the original color of button in both light mode and dark mode. So I replace the buttonColor with background color, and it works.

## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

