### PR TITLE
replaced deprecated uses of brightness

### DIFF
--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -2,6 +2,7 @@ import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:campus_mobile_experimental/core/providers/bottom_nav.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 class CMAppBar extends StatelessWidget {
@@ -20,7 +21,6 @@ class CMAppBar extends StatelessWidget {
           preferredSize: Size.fromHeight(42),
           child: AppBar(
               backgroundColor: ColorPrimary,
-              brightness: Brightness.dark,
               primary: true,
               centerTitle: true,
               title: title == null
@@ -56,13 +56,13 @@ class CMAppBar extends StatelessWidget {
                             .changeTitle(CustomAppBar().appBar.title);
                       },
                     ))
-              ]));
+              ],
+              systemOverlayStyle: SystemUiOverlayStyle.light));
     } else {
       return PreferredSize(
         preferredSize: Size.fromHeight(42),
         child: AppBar(
           backgroundColor: ColorPrimary,
-          brightness: Brightness.dark,
           primary: true,
           centerTitle: true,
           title: title == null
@@ -72,6 +72,7 @@ class CMAppBar extends StatelessWidget {
                   height: 28,
                 )
               : Text(title!),
+          systemOverlayStyle: SystemUiOverlayStyle.light,
         ),
       );
     }

--- a/lib/ui/onboarding/onboarding_affiliations.dart
+++ b/lib/ui/onboarding/onboarding_affiliations.dart
@@ -1,6 +1,7 @@
 import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'onboarding_login.dart';
@@ -21,7 +22,7 @@ class _OnboardingAffiliationsState extends State<OnboardingAffiliations> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0.0,
-        brightness: Brightness.dark,
+        systemOverlayStyle: SystemUiOverlayStyle.light,
       ),
       body: Semantics(
         label:

--- a/lib/ui/onboarding/onboarding_login.dart
+++ b/lib/ui/onboarding/onboarding_login.dart
@@ -2,6 +2,7 @@ import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:campus_mobile_experimental/core/providers/user.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -29,7 +30,7 @@ class _OnboardingLoginState extends State<OnboardingLogin> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0.0,
-        brightness: Brightness.dark,
+        systemOverlayStyle: SystemUiOverlayStyle.light,
       ),
       backgroundColor: lightPrimaryColor, // ColorPrimary, //Colors.white,
       body: _userDataProvider.isLoading!

--- a/lib/ui/scanner/native_scanner_view.dart
+++ b/lib/ui/scanner/native_scanner_view.dart
@@ -4,6 +4,7 @@ import 'package:campus_mobile_experimental/core/providers/scanner_message.dart';
 import 'package:campus_mobile_experimental/core/providers/user.dart';
 import 'package:campus_mobile_experimental/core/utils/webview.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_scandit_plugin/flutter_scandit_plugin.dart';
 import 'package:intl/intl.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -29,9 +30,9 @@ class _ScanditScannerState extends State<ScanditScanner> {
         preferredSize: Size.fromHeight(42),
         child: AppBar(
           backgroundColor: ColorPrimary,
-          brightness: Brightness.dark,
           centerTitle: true,
           title: const Text("Scanner"),
+          systemOverlayStyle: SystemUiOverlayStyle.light,
         ),
       ),
       body: !_scannerDataProvider.hasScanned!


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? -->
Replaces deprecated occurrences of brightness in code with new SystemUiOverlayStyle class according to Flutter's recommendations ([see link for refrence](https://api.flutter.dev/flutter/material/AppBar/brightness.html#:~:text=determines%20the%20brightness%20of%20the%20systemuioverlaystyle%3A%20for%20brightness.dark%2C%20systemuioverlaystyle.light%20is%20used%20and%20for%20brightness.light%2C%20systemuioverlaystyle.dark%20is%20used.))

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Change] - replaced deprecated occurrences of brightness


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

Changes affect the following screens which should be examined for any errors or visual differences when compared to previous versions of the app (there should be **no** functional or visual differences):
- navigator/top
- onboarding/onboarding_affiliations
- onboarding/onboarding_login
- scanner/native_scanner_view

