### PR TITLE
Package upgrade: flutter_sticky_header 0.6.0 --> 0.6.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter_linkify: 5.0.2
   flutter_local_notifications: 8.2.0
   flutter_secure_storage: 5.0.2
-  flutter_sticky_header: 0.6.0
+  flutter_sticky_header: 0.6.4
   get: 4.1.4
   google_maps_flutter: 2.0.6
   hive: 2.0.4


### PR DESCRIPTION
## Summary
Package upgrade: flutter_sticky_header 0.6.0 --> 0.6.4

## Changelog
[General] [Change] - Upgrade `flutter_sticky_header` from `0.6.0` to `0.6.4` ([changelog](https://pub.dev/packages/flutter_sticky_header/changelog))

## Test Plan
Regression test the following areas:
```
./lib/ui/classes/classes_list.dart

```