### PR TITLE
fix flutter deprecation - cupertino import

### DIFF
--- a/lib/ui/shuttle/shuttle_display.dart
+++ b/lib/ui/shuttle/shuttle_display.dart
@@ -1,7 +1,6 @@
 import 'package:campus_mobile_experimental/core/models/shuttle.dart';
 import 'package:campus_mobile_experimental/core/models/shuttle_arrival.dart';
 import 'package:campus_mobile_experimental/core/models/shuttle_stop.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 

--- a/lib/ui/wifi/wifi_card.dart
+++ b/lib/ui/wifi/wifi_card.dart
@@ -6,7 +6,6 @@ import 'package:campus_mobile_experimental/core/providers/cards.dart';
 import 'package:campus_mobile_experimental/core/providers/speed_test.dart';
 import 'package:campus_mobile_experimental/core/providers/user.dart';
 import 'package:campus_mobile_experimental/ui/common/card_container.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:liquid_progress_indicator/liquid_progress_indicator.dart';


### PR DESCRIPTION
Fixed flutter deprecations issue: "The import of 'package:flutter/cupertino.dart' is unnecessary"