### PR TITLE
Notifications Tab: Add topic icons to notification settings view

### DIFF
--- a/lib/ui/notifications/notifications_list_view.dart
+++ b/lib/ui/notifications/notifications_list_view.dart
@@ -113,69 +113,67 @@ class NotificationsListView extends StatelessWidget {
         Provider.of<FreeFoodDataProvider>(context);
 
     String? messageType;
-    if(data.audience!.topics == null)  {
+    if (data.audience!.topics == null) {
       messageType = "DM";
-    }
-    else {
+    } else {
       messageType = data.audience?.topics![0];
     }
 
-
     return ListTile(
-      leading: Icon(_chooseIcon(messageType!), color: Theme.of(context).colorScheme.secondary, size: 30),
-      title: Column(
-        children: <Widget>[
-          Text(data.message!.title!, style: TextStyle(fontWeight: FontWeight.bold),),
-          Padding(padding: const EdgeInsets.all(3.5))
-        ],
-        crossAxisAlignment: CrossAxisAlignment.start,
-      ),
-      subtitle: Column(
-        children: <Widget>[
-          Align(
-            alignment: Alignment.topLeft,
-            child: Linkify(
-              text: data.message!.message!,
-              onOpen: (link) async {
-                try {
-                  await launch(link.url, forceSafariVC: true);
-                } catch (e) {
-                  // an error occurred, do nothing
-                }
-              },
-              options: LinkifyOptions(humanize: false),
-              style: TextStyle(fontSize: 12.5),
-            ),
-          ),
-          freefoodProvider.isFreeFood(data.messageId)
-              ? FreeFoodNotification(messageId: data.messageId)
-              : Container(),
-        ],
-      ),
-        trailing: Column(
+        leading: Icon(_chooseIcon(messageType!),
+            color: Theme.of(context).colorScheme.secondary, size: 30),
+        title: Column(
           children: <Widget>[
-            Text(_readTimestamp(data.timestamp!),
-                style: TextStyle(fontSize: 10, color: Colors.grey)),
-          ]
-      )
-    );
+            Text(
+              data.message!.title!,
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            Padding(padding: const EdgeInsets.all(3.5))
+          ],
+          crossAxisAlignment: CrossAxisAlignment.start,
+        ),
+        subtitle: Column(
+          children: <Widget>[
+            Align(
+              alignment: Alignment.topLeft,
+              child: Linkify(
+                text: data.message!.message!,
+                onOpen: (link) async {
+                  try {
+                    await launch(link.url, forceSafariVC: true);
+                  } catch (e) {
+                    // an error occurred, do nothing
+                  }
+                },
+                options: LinkifyOptions(humanize: false),
+                style: TextStyle(fontSize: 12.5),
+              ),
+            ),
+            freefoodProvider.isFreeFood(data.messageId)
+                ? FreeFoodNotification(messageId: data.messageId)
+                : Container(),
+          ],
+        ),
+        trailing: Column(children: <Widget>[
+          Text(_readTimestamp(data.timestamp!),
+              style: TextStyle(fontSize: 10, color: Colors.grey)),
+        ]));
   }
 
   IconData _chooseIcon(String messageType) {
-    if (messageType == "studentAnnouncements" || messageType == "testStudentAnnouncements") {
+    if (messageType == "studentAnnouncements" ||
+        messageType == "testStudentAnnouncements") {
       return Icons.school_outlined;
-    }
-    else if (messageType == "freeFood") {
+    } else if (messageType == "freeFood") {
       return Icons.restaurant_outlined;
-    }
-    else if (messageType == "campusAnnouncements" || messageType == "testCampusAnnouncements") {
-        return Icons.campaign_outlined;
-    }
-    else if (messageType == "DM"){
+    } else if (messageType == "campusAnnouncements" ||
+        messageType == "testCampusAnnouncements") {
+      return Icons.campaign_outlined;
+    } else if (messageType == "DM") {
       return Icons.info_outline;
     }
     return Icons.info_outline;
-}
+  }
 
   String _readTimestamp(int timestamp) {
     var now = new DateTime.now();

--- a/lib/ui/profile/notifications.dart
+++ b/lib/ui/profile/notifications.dart
@@ -25,6 +25,8 @@ class NotificationsSettingsView extends StatelessWidget {
     for (String? topic in topicsAvailable) {
       list.add(ListTile(
         key: Key(topic!),
+        leading: Icon(_chooseIcons(topic),
+            color: Theme.of(context).colorScheme.secondary, size: 30),
         title: Text(getTopicName(context, topic)!),
         trailing: Switch(
           value: Provider.of<PushNotificationDataProvider>(context)
@@ -39,6 +41,21 @@ class NotificationsSettingsView extends StatelessWidget {
       ));
     }
     return list;
+  }
+
+  IconData _chooseIcons(String messageType) {
+    if (messageType == "studentAnnouncements" ||
+        messageType == "testStudentAnnouncements") {
+      return Icons.school_outlined;
+    } else if (messageType == "freeFood" || messageType == "testFreeFood") {
+      return Icons.restaurant_outlined;
+    } else if (messageType == "campusAnnouncements" ||
+        messageType == "testCampusAnnouncements") {
+      return Icons.campaign_outlined;
+    } else if (messageType == "DM") {
+      return Icons.info_outline;
+    }
+    return Icons.info_outline;
   }
 
   List<String?> getTopics(BuildContext context) {


### PR DESCRIPTION
## Summary
<!-- What existing problem does the pull request solve? --> Made changes to the list_view method and added a new method to create the notifications


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Add] - adding notification icons to the profile topic.

## Test Plan
<!--
    1. We copied a method over from the notifications tab to the profile/notifications. dart file
    2. Afterwards, we modified an existing method(createList) to display our notification icons. 

    Include screenshots and/or videos if the pull request changes the user interface.
-->
![image](https://user-images.githubusercontent.com/105324767/218376354-be39d967-8a94-43c8-b0d3-975085608929.png)

![image](https://user-images.githubusercontent.com/105324767/218376386-00546b7a-d76a-4eb8-8672-85a71f7b30cc.png)

