### PR TITLE
Notifications Tab: Add topic filter 

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -11,8 +11,7 @@ class RoutePaths {
   static const String Notifications = 'notifications';
   static const String Profile = 'profile';
   static const String CardsView = 'profile/cards_view';
-  static const String NotificationsSettingsView =
-      'notifications/notifications_settings';
+  static const String NotificationsFilter = 'notifications/filter';
 
   static const String NewsViewAll = 'news/newslist';
   static const String EventsViewAll = 'events/eventslist';
@@ -48,7 +47,7 @@ class RouteTitles {
     'Notifications': 'Notifications',
     'Profile': 'Profile',
     'profile/cards_view': 'Cards',
-    'notifications/notifications_settings': "Notification Settings",
+    'notifications/filter': "Filter",
     'news/newslist': 'News',
     'news/news_detail_view': 'News',
     'events/eventslist': 'Events',

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -152,7 +152,7 @@ class Router {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return CardsView();
         });
-      case RoutePaths.NotificationsSettingsView:
+      case RoutePaths.NotificationsFilter:
         return MaterialPageRoute(builder: (_) {
           Provider.of<CustomAppBar>(_).changeTitle(settings.name);
           return NotificationsSettingsView();

--- a/lib/ui/navigator/bottom.dart
+++ b/lib/ui/navigator/bottom.dart
@@ -45,8 +45,10 @@ class _BottomTabBarState extends State<BottomTabBar> {
                   .changeTitle("Maps");
               break;
             case NavigatorConstants.NotificationsTab:
-              Provider.of<CustomAppBar>(context, listen: false)
-                  .changeTitle("Notifications");
+              Provider.of<CustomAppBar>(context, listen: false).changeTitle(
+                  "Notifications",
+                  done: false,
+                  notification: true);
               break;
             case NavigatorConstants.ProfileTab:
               Provider.of<CustomAppBar>(context, listen: false)

--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -9,10 +9,12 @@ class CMAppBar extends StatelessWidget {
   CMAppBar({
     this.title,
     this.doneButton,
+    this.notificationsFilterButton,
   });
 
   final String? title;
   final bool? doneButton;
+  final bool? notificationsFilterButton;
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +60,30 @@ class CMAppBar extends StatelessWidget {
                     ))
               ],
               systemOverlayStyle: SystemUiOverlayStyle.light));
+    } else if (notificationsFilterButton == true) {
+      return PreferredSize(
+          preferredSize: Size.fromHeight(42),
+          child: AppBar(
+              backgroundColor: ColorPrimary,
+              primary: true,
+              centerTitle: true,
+              title: title == null
+                  ? Image.asset(
+                      'assets/images/UCSanDiegoLogo-nav.png',
+                      fit: BoxFit.contain,
+                      height: 28,
+                    )
+                  : Text(title!),
+              actions: <Widget>[
+                IconButton(
+                  icon: Icon(Icons.filter_list_outlined),
+                  onPressed: () {
+                    Navigator.pushNamed(
+                        context, RoutePaths.NotificationsFilter);
+                  },
+                )
+              ],
+              systemOverlayStyle: SystemUiOverlayStyle.light));
     } else {
       return PreferredSize(
         preferredSize: Size.fromHeight(42),
@@ -83,6 +109,7 @@ class CustomAppBar extends ChangeNotifier {
   late CMAppBar appBar;
   String? title;
   bool? doneButton;
+  bool? notificationsFilterButton;
 
   CustomAppBar() {
     makeAppBar();
@@ -92,12 +119,21 @@ class CustomAppBar extends ChangeNotifier {
     appBar = CMAppBar(
       title: title,
       doneButton: doneButton,
+      notificationsFilterButton: notificationsFilterButton,
     );
   }
 
-  changeTitle(String? newTitle, {done: false}) {
+  changeTitle(String? newTitle, {done: false, notification: false}) {
     title = RouteTitles.titleMap[newTitle];
     doneButton = done;
+    notificationsFilterButton = notification;
+
+    // if (newTitle == "Notifications") {
+    //   notificationsFilterButton = true;
+    // } else {
+    //   notificationsFilterButton = false;
+    // }
+
     makeAppBar();
   }
 }

--- a/lib/ui/profile/profile.dart
+++ b/lib/ui/profile/profile.dart
@@ -41,15 +41,15 @@ class Profile extends StatelessWidget {
       child: ListView(
         children: <Widget>[
           Login(),
-          Card(
-            child: ListTile(
-              leading: Icon(Icons.notifications),
-              title: Text('Notifications'),
-              onTap: () {
-                handleNotificationsTap(context);
-              },
-            ),
-          ),
+          // Card(
+          //   child: ListTile(
+          //     leading: Icon(Icons.notifications),
+          //     title: Text('Notifications'),
+          //     onTap: () {
+          //       handleNotificationsTap(context);
+          //     },
+          //   ),
+          // ),
           Card(
             child: ListTile(
               leading: Icon(Icons.menu),
@@ -79,9 +79,9 @@ class Profile extends StatelessWidget {
     );
   }
 
-  handleNotificationsTap(BuildContext context) {
-    Navigator.pushNamed(context, RoutePaths.NotificationsSettingsView);
-  }
+  // handleNotificationsTap(BuildContext context) {
+  //   Navigator.pushNamed(context, RoutePaths.NotificationsFilter);
+  // }
 
   handleFeedbackTap() async {
     const feedbackUrl = "https://eforms.ucsd.edu/view.php?id=668781";


### PR DESCRIPTION
## Summary
[Notifications Tab: Add topic filter Issue](https://github.com/UCSD/campus-mobile/issues/1866)
-  Filter button added to Notifications tab nav bar
- Filter button linked to existing Notifications Settings View
- "Notification Settings" view nav bar title changed to "Filter"
- Notification Settings link removed from Profile tab
-
## Changelog
[General][Add] - Added a filter button linked to Notifications Settings View
[General][Change] - changed nav bar title to Filter 
[General][Remove] - removed Notification Settings link from Profile Tab 

## Test Plan
1. Go to Notifications and click on the Filter button. This should lead you to the "Notifcations Settings View" that is now titled "Filter".

