### PR TITLE
Replace device_info package with device_info_plus

### DIFF
--- a/lib/core/providers/notifications.dart
+++ b/lib/core/providers/notifications.dart
@@ -7,7 +7,7 @@ import 'package:campus_mobile_experimental/core/providers/bottom_nav.dart';
 import 'package:campus_mobile_experimental/core/providers/messages.dart';
 import 'package:campus_mobile_experimental/core/services/notifications.dart';
 import 'package:campus_mobile_experimental/ui/navigator/top.dart';
-import 'package:device_info/device_info.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -217,7 +217,7 @@ class PushNotificationDataProvider extends ChangeNotifier {
       'tags': build.tags,
       'type': build.type,
       'isPhysicalDevice': build.isPhysicalDevice,
-      'deviceId': build.androidId,
+      'deviceId': build.id,
       'systemFeatures': build.systemFeatures,
     };
   }

--- a/lib/core/services/speed_test.dart
+++ b/lib/core/services/speed_test.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:campus_mobile_experimental/app_networking.dart';
 import 'package:campus_mobile_experimental/core/models/speed_test.dart';
 import 'package:connectivity/connectivity.dart';
-import 'package:device_info/device_info.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:wifi_connection/WifiConnection.dart';
 import 'package:wifi_connection/WifiInfo.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -273,22 +273,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.8"
-  device_info:
+  device_info_plus:
     dependency: "direct main"
     description:
-      name: device_info
-      sha256: "8f07d3647ec6025dcc5f56c4c9a749257e1389774361aa999e2b4fc7dd6f3ded"
+      name: device_info_plus
+      sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
-  device_info_platform_interface:
+    version: "9.1.2"
+  device_info_plus_platform_interface:
     dependency: transitive
     description:
-      name: device_info_platform_interface
-      sha256: b148e0bf9640145d09a4f8dea96614076f889e7f7f8b5ecab1c7e5c2dbc73c1b
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "7.0.0"
   dio:
     dependency: "direct main"
     description:
@@ -1400,6 +1400,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.4"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "1c52f994bdccb77103a6231ad4ea331a244dbcef5d1f37d8462f713143b0bfae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
 dependencies:
   barcode_widget: 2.0.3
   connectivity: 3.0.6
-  device_info: 2.0.2
   dio: 4.0.6
   encrypt: 5.0.1
   dots_indicator: 2.1.0
@@ -51,6 +50,7 @@ dependencies:
   audio_service: ^0.18.9
   just_audio: ^0.9.31
   just_audio_background: ^0.0.1-beta.9
+  device_info_plus: ^9.1.2
 dev_dependencies:
   build_runner: 2.0.2
   flutter_test:


### PR DESCRIPTION
## Summary
Fixes Issue #1877 - Replaces the device_info package with the device_info_plus package


## Changelog
[General] [Change] - Changes out the device info package with the device info plus package


## Test Plan
This push request doesn't really change any "functional" code in the app, it just exchanges the package it runs the code through. Therefore, general app testing would be appreciated, but no particular issues or differences are expected (if any differences are found, please note them).

--Files in-app using the new package:
lib/core/providers/notifications.dart
lib/core/services/speed_test.dart