### PR TITLE
Fixed Deprecated Flutter Warnings for #2039

### DIFF
--- a/lib/app_styles.dart
+++ b/lib/app_styles.dart
@@ -76,14 +76,14 @@ const IconThemeData darkIconTheme = IconThemeData(
 
 //Colors for text on buttons using light theme
 const TextTheme lightThemeText = TextTheme(
-  button: TextStyle(
+  labelLarge: TextStyle(
     color: lightTextColor,
   ),
 );
 
 //Colors for text on buttons using dark theme
 const TextTheme darkThemeText = TextTheme(
-  button: TextStyle(color: darkTextColor),
+  labelLarge: TextStyle(color: darkTextColor),
 );
 
 //Button color for themes

--- a/lib/ui/common/dots_indicator.dart
+++ b/lib/ui/common/dots_indicator.dart
@@ -9,7 +9,7 @@ class DotsIndicator extends AnimatedWidget {
     required this.controller,
     this.itemCount,
     this.onPageSelected,
-    this.color: Colors.grey,
+    this.color = Colors.grey,
   }) : super(listenable: controller);
 
   /// The PageController that this DotsIndicator is representing.

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -107,7 +107,7 @@ class DiningDetailView extends StatelessWidget {
         ),
         child: Text('Visit Website',
             style: TextStyle(
-              color: Theme.of(context).textTheme.button!.color,
+              color: Theme.of(context).textTheme.labelLarge!.color,
             )),
         onPressed: () {
           try {
@@ -126,7 +126,7 @@ class DiningDetailView extends StatelessWidget {
       return ElevatedButton(
         child: Text('View Menu',
             style: TextStyle(
-              color: Theme.of(context).textTheme.button!.color,
+              color: Theme.of(context).textTheme.labelLarge!.color,
             )),
         style: ElevatedButton.styleFrom(
           foregroundColor: Theme.of(context).primaryColor,
@@ -179,8 +179,8 @@ Widget buildSpecialHours(BuildContext context, prefix0.DiningModel model){
   return RichText(
     text: TextSpan(
       style: TextStyle(
-          fontSize: Theme.of(context).textTheme.bodyText2!.fontSize,
-          color: Theme.of(context).textTheme.bodyText2!.color),
+          fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+          color: Theme.of(context).textTheme.bodyMedium!.color),
       children: [
         TextSpan(
           text: "Special Hours: \n",
@@ -201,8 +201,8 @@ Widget buildSpecialHours(BuildContext context, prefix0.DiningModel model){
     return RichText(
       text: TextSpan(
         style: TextStyle(
-            fontSize: Theme.of(context).textTheme.bodyText2!.fontSize,
-            color: Theme.of(context).textTheme.bodyText2!.color),
+            fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+            color: Theme.of(context).textTheme.bodyMedium!.color),
         children: [
           TextSpan(
             text: "Payment Options:\n",

--- a/lib/ui/dining/dining_menu_list.dart
+++ b/lib/ui/dining/dining_menu_list.dart
@@ -74,7 +74,7 @@ class _DiningMenuListState extends State<DiningMenuList> {
                   TextSpan(
                     text: " (\$${item.price})",
                     style: TextStyle(
-                        color: Theme.of(context).textTheme.bodyText2!.color),
+                        color: Theme.of(context).textTheme.bodyMedium!.color),
                   )
                 ],
               ),
@@ -133,7 +133,7 @@ class _DiningMenuListState extends State<DiningMenuList> {
       child: ToggleButtons(
         isSelected: Provider.of<DiningDataProvider>(context).filtersSelected,
         textStyle: TextStyle(fontSize: 18),
-        selectedColor: Theme.of(context).textTheme.button!.color,
+        selectedColor: Theme.of(context).textTheme.labelLarge!.color,
         // fillColor: Theme.of(context).buttonColor,
         fillColor: Theme.of(context).backgroundColor,
         borderRadius: BorderRadius.circular(10),

--- a/lib/ui/dining/nutrition_facts_view.dart
+++ b/lib/ui/dining/nutrition_facts_view.dart
@@ -179,8 +179,8 @@ Widget nutrientLiner({
   required qty,
   required context,
   ptg,
-  sub: false,
-  showPercent: true,
+  sub = false,
+  showPercent = true,
 }) {
   final textSize = 15.0;
   final textWeight1 = FontWeight.w900;

--- a/lib/ui/events/events_detail_view.dart
+++ b/lib/ui/events/events_detail_view.dart
@@ -112,7 +112,7 @@ class LearnMoreButton extends StatelessWidget {
           child: Text(
             'Learn More',
             style: TextStyle(
-                fontSize: 16, color: Theme.of(context).textTheme.button!.color),
+                fontSize: 16, color: Theme.of(context).textTheme.labelLarge!.color),
           ),
           onPressed: () async {
             try {

--- a/lib/ui/map/more_results_list.dart
+++ b/lib/ui/map/more_results_list.dart
@@ -73,7 +73,7 @@ class MoreResultsList extends StatelessWidget {
         ),
         child: Text(
           'Show More Results',
-          style: TextStyle(color: Theme.of(context).textTheme.button!.color),
+          style: TextStyle(color: Theme.of(context).textTheme.labelLarge!.color),
         ),
       ),
     );

--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -123,7 +123,7 @@ class CustomAppBar extends ChangeNotifier {
     );
   }
 
-  changeTitle(String? newTitle, {done: false, notification: false}) {
+  changeTitle(String? newTitle, {done = false, notification = false}) {
     title = RouteTitles.titleMap[newTitle];
     doneButton = done;
     notificationsFilterButton = notification;

--- a/lib/ui/news/news_detail_view.dart
+++ b/lib/ui/news/news_detail_view.dart
@@ -78,7 +78,7 @@ class ContinueReadingButton extends StatelessWidget {
           child: Text(
             'Continue Reading',
             style: TextStyle(
-                fontSize: 18, color: Theme.of(context).textTheme.button!.color),
+                fontSize: 18, color: Theme.of(context).textTheme.labelLarge!.color),
           ),
         ),
       ),

--- a/lib/ui/profile/login.dart
+++ b/lib/ui/profile/login.dart
@@ -160,7 +160,7 @@ class _LoginState extends State<Login> {
                       'Sign In',
                       style: TextStyle(
                           fontSize: 18,
-                          color: Theme.of(context).textTheme.button!.color),
+                          color: Theme.of(context).textTheme.labelLarge!.color),
                     ),
                     onPressed: _userDataProvider.isLoading!
                         ? null

--- a/lib/ui/scanner/native_scanner_view.dart
+++ b/lib/ui/scanner/native_scanner_view.dart
@@ -155,7 +155,7 @@ class _ScanditScannerState extends State<ScanditScanner> {
                     "Try again",
                     style: TextStyle(
                         fontSize: 18.0,
-                        color: Theme.of(context).textTheme.button!.color),
+                        color: Theme.of(context).textTheme.labelLarge!.color),
                   ),
                 ),
               ),

--- a/lib/ui/triton_media/triton_media_detail_view.dart
+++ b/lib/ui/triton_media/triton_media_detail_view.dart
@@ -156,7 +156,7 @@ class BroadcastScheduleButton extends StatelessWidget {
           child: Text(
             'Broadcast Schedule',
             style: TextStyle(
-                fontSize: 16, color: Theme.of(context).textTheme.button!.color),
+                fontSize: 16, color: Theme.of(context).textTheme.labelLarge!.color),
           ),
           onPressed: () async {
             try {


### PR DESCRIPTION
## Summary
Resolves flutter deprecations. Specifically `button`, `bodyText2`, and `using a colon as a separator`.

Fixes Issue #2039 

## Changelog
[General] [Fix] - Resolve `'button' is deprecated and shouldn't be used`.
[General] [Fix] - Resolve `'bodyText2' is deprecated and shouldn't be used`.
[General] [Fix] - Resolve `Using a colon as a separator before a default value is deprecated`.


## Test Plan
General Testing of the app should be done. Additional attention should be paid to the files that are changed (check commit for these files). No functionality or UI should be changed.
