### PR TITLE
Upgrade to scandit 6.6.3

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -498,8 +498,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "41fb666299ed90d8277c24e0065149e83cd71494"
-      resolved-ref: "41fb666299ed90d8277c24e0065149e83cd71494"
+      ref: "scandit-6.6.3"
+      resolved-ref: d99208e0ff297e0943075ad2546af4a8ebc03d63
       url: "https://github.com/UCSD/flutter_scandit.git"
     source: git
     version: "1.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter_scandit_plugin:
     git:
       url: https://github.com/UCSD/flutter_scandit.git
-      ref: 41fb666299ed90d8277c24e0065149e83cd71494
+      ref: scandit-6.6.3
   flutter_linkify: 5.0.2
   flutter_local_notifications: 9.9.1
   flutter_secure_storage: 5.0.2


### PR DESCRIPTION
## Summary
Upgrade to scandit 6.6.3 to resolve Android build error relating to obsolete scandit 6.6.0-beta.2.


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Upgrade to scandit 6.6.3 to resolve Android build error


## Test Plan
Regression test scanner features and functionality

