### PR TITLE
Increase Networking Timeout Default

### DIFF
--- a/lib/app_networking.dart
+++ b/lib/app_networking.dart
@@ -14,11 +14,12 @@ class NetworkHelper {
   static const int SSO_REFRESH_MAX_RETRIES = 3;
   static const int SSO_REFRESH_RETRY_INCREMENT = 5000;
   static const int SSO_REFRESH_RETRY_MULTIPLIER = 3;
+  static const int DEFAULT_TIMEOUT = 60000;
 
   Future<dynamic> fetchData(String url) async {
     Dio dio = new Dio();
-    dio.options.connectTimeout = 20000;
-    dio.options.receiveTimeout = 20000;
+    dio.options.connectTimeout = DEFAULT_TIMEOUT;
+    dio.options.receiveTimeout = DEFAULT_TIMEOUT;
     dio.options.responseType = ResponseType.plain;
     final _response = await dio.get(url);
 
@@ -35,8 +36,8 @@ class NetworkHelper {
   Future<dynamic> authorizedFetch(
       String url, Map<String, String> headers) async {
     Dio dio = new Dio();
-    dio.options.connectTimeout = 20000;
-    dio.options.receiveTimeout = 20000;
+    dio.options.connectTimeout = DEFAULT_TIMEOUT;
+    dio.options.receiveTimeout = DEFAULT_TIMEOUT;
     dio.options.responseType = ResponseType.plain;
     dio.options.headers = headers;
     final _response = await dio.get(
@@ -111,8 +112,8 @@ class NetworkHelper {
   Future<dynamic> authorizedPost(
       String url, Map<String, String>? headers, dynamic body) async {
     Dio dio = new Dio();
-    dio.options.connectTimeout = 20000;
-    dio.options.receiveTimeout = 20000;
+    dio.options.connectTimeout = DEFAULT_TIMEOUT;
+    dio.options.receiveTimeout = DEFAULT_TIMEOUT;
     dio.options.headers = headers;
     final _response = await dio.post(url, data: body);
     if (_response.statusCode == 200 || _response.statusCode == 201) {
@@ -142,8 +143,8 @@ class NetworkHelper {
   Future<dynamic> authorizedPut(
       String url, Map<String, String> headers, dynamic body) async {
     Dio dio = new Dio();
-    dio.options.connectTimeout = 20000;
-    dio.options.receiveTimeout = 20000;
+    dio.options.connectTimeout = DEFAULT_TIMEOUT;
+    dio.options.receiveTimeout = DEFAULT_TIMEOUT;
     dio.options.headers = headers;
     final _response = await dio.put(url, data: body);
 
@@ -171,8 +172,8 @@ class NetworkHelper {
   Future<dynamic> authorizedDelete(
       String url, Map<String, String> headers) async {
     Dio dio = new Dio();
-    dio.options.connectTimeout = 20000;
-    dio.options.receiveTimeout = 20000;
+    dio.options.connectTimeout = DEFAULT_TIMEOUT;
+    dio.options.receiveTimeout = DEFAULT_TIMEOUT;
     dio.options.headers = headers;
     try {
       final _response = await dio.delete(url);


### PR DESCRIPTION
## Summary
Problem: Smoke tests failing in QA due to intermittent API/services slowness

Solution: Allow more time for requests to process in the QA environment

Notes:
- QA networking request timeout: 60s
- PROD networking request timeout: 20s (no change)


