### PR TITLE
Fix free food PROD bug

### DIFF
--- a/lib/core/models/notifications.dart
+++ b/lib/core/models/notifications.dart
@@ -72,6 +72,7 @@ class Audience {
 }
 
 class Message {
+
   String message;
   String title;
   Data data;
@@ -83,8 +84,9 @@ class Message {
   });
 
   Message.fromJson(Map<String, dynamic> json)
-      : message = json["message"],
-        title = json["title"],
+      // Defaulting to empty strings until we figure out what should or should not be null on the backend
+      : message = json["message"] ?? "",
+        title = json["title"] ?? "",
         data = Data.fromJson(json["data"]);
 
   Map<String, dynamic> toJson() => {


### PR DESCRIPTION
## Summary
This fixes the recent PROD bug. Apparently, it was caused by inconsistent message data being returned from PROD endpoints. Certain messages could have no title and no body either.

## Changelog
- The title and body of message models now default to empty strings

## Test Plan
Retest existing PROD builds.
