### PR TITLE
Default card order fix

### DIFF
--- a/lib/core/providers/cards.dart
+++ b/lib/core/providers/cards.dart
@@ -26,6 +26,7 @@ class CardsDataProvider extends ChangeNotifier {
   String? _error;
 
   // Default card order for native cards
+  // Most of the time immediately overwritten by default card order coming from server
   List<String> _cardOrder = [
     'NativeScanner',
     'MyStudentChart',
@@ -92,8 +93,8 @@ class CardsDataProvider extends ChangeNotifier {
               if (model.isWebCard)
                 _webCards[card] = model;
 
-              if (!_cardOrder.contains(model) && (model.cardActive))
-                _cardOrder.insert(0, card);
+              if (!_cardOrder.contains(model) && model.cardActive)
+                _cardOrder.add(card);
 
               // keep all new cards activated by default
               _cardStates.putIfAbsent(card, () => true);


### PR DESCRIPTION
## Summary
Until now, our cards have been displayed in reverse order from the data received from cards endpoint yet still stored in persistent storage in original order.


## Changelog
- Fixes default card order bug
- Minor code readability enhancement


## Test Plan
TODO: add here after build is complete