### PR TITLE
Default card order fix

### DIFF
--- a/lib/core/providers/cards.dart
+++ b/lib/core/providers/cards.dart
@@ -26,6 +26,7 @@ class CardsDataProvider extends ChangeNotifier {
   String? _error;
 
   // Default card order for native cards
+  // Most of the time immediately overwritten by default card order coming from server
   List<String> _cardOrder = [
     'NativeScanner',
     'MyStudentChart',
@@ -92,8 +93,8 @@ class CardsDataProvider extends ChangeNotifier {
               if (model.isWebCard)
                 _webCards[card] = model;
 
-              if (!_cardOrder.contains(model) && (model.cardActive))
-                _cardOrder.insert(0, card);
+              if (!_cardOrder.contains(model) && model.cardActive)
+                _cardOrder.add(card);
 
               // keep all new cards activated by default
               _cardStates.putIfAbsent(card, () => true);


### PR DESCRIPTION
## Summary
Until now, our cards have been displayed in reverse order from the data received from cards endpoint yet still stored in persistent storage in original order.


## Changelog
- Fixes default card order bug
- Minor code readability enhancement


## Test Plan
[PR-2105-Test-Plan-7.30.0-QA-3380.xlsx (Android)](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B1B1F1F08-0686-4825-84AB-AC0E6720196E%7D&file=[PR-2105-Test-Plan-7.30.0-QA-3380.xlsx](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B1B1F1F08-0686-4825-84AB-AC0E6720196E%7D&file=PR-2105-Test-Plan-7.30.0-QA-3380.xlsx&action=default&mobileredirect=true)&action=default&mobileredirect=true)
[PR-2105-Test-Plan-7.30.0-QA-3381.xlsx (iOS)](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B3FBAC20A-BDD5-44D8-87ED-EB11929EF974%7D&file=[PR-2105-Test-Plan-7.30.0-QA-3381.xlsx](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B3FBAC20A-BDD5-44D8-87ED-EB11929EF974%7D&file=PR-2105-Test-Plan-7.30.0-QA-3381.xlsx&action=default&mobileredirect=true)&action=default&mobileredirect=true)