### PR TITLE
Removed Markets from the Busyness card

### DIFF
--- a/lib/core/models/availability.dart
+++ b/lib/core/models/availability.dart
@@ -24,10 +24,14 @@ class AvailabilityStatus {
   factory AvailabilityStatus.fromJson(Map<String, dynamic> json) =>
       AvailabilityStatus(
         status: json["status"]!,
-        // TODO: rewrite this to be shorter! Hint: use functional style iterators...
+        // TODO: rewrite this to be shorter! Functional style iterators?...
         data: ((){
           List<AvailabilityModel> returnList = List<AvailabilityModel>.from(
               json["data"]!.map((x) => AvailabilityModel.fromJson(x)));
+
+          // TODO: remove this line after the missing Markets data is fixed on the backend
+          returnList.removeWhere((model) => model.name == "Markets");
+
           for (int index = 0; index < returnList.length; index++) {
             if (returnList[index].subLocations.length > 3) {
               String baseName = returnList[index].name;

--- a/lib/core/providers/availability.dart
+++ b/lib/core/providers/availability.dart
@@ -106,9 +106,9 @@ class AvailabilityDataProvider extends ChangeNotifier {
   }
 
   /// SIMPLE GETTERS
-  get isLoading => _isLoading;
-  get error => _error;
-  get lastUpdated => _lastUpdated;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  DateTime? get lastUpdated => _lastUpdated;
   Map<String?, bool> get locationViewState => _locationViewState;
   List<AvailabilityModel?> get availabilityModels =>
       makeOrderedList(userDataProvider.userProfileModel.selectedOccuspaceLocations);

--- a/lib/core/services/availability.dart
+++ b/lib/core/services/availability.dart
@@ -17,16 +17,16 @@ class AvailabilityService {
   /// add any type of data manipulation here so it can be accessed via provider
 
   /// SERVICES
-  final _networkHelper = NetworkHelper();
+  static const _networkHelper = NetworkHelper();
 
   Future<bool> fetchData() async {
     _error = null; _isLoading = true;
     try {
       /// fetch data
-      String _response = await (_networkHelper.authorizedFetch(
-          dotenv.get('AVAILABILITY_API_ENDPOINT'), {
-        "Authorization": dotenv.get('MOBILE_APP_PUBLIC_DATA_KEY')
-      }));
+      String _response = await _networkHelper.authorizedFetch(
+          dotenv.get('AVAILABILITY_API_ENDPOINT'),
+          { "Authorization": dotenv.get('MOBILE_APP_PUBLIC_DATA_KEY') }
+      );
 
       /// parse data
       final data = availabilityStatusFromJson(_response);
@@ -41,8 +41,8 @@ class AvailabilityService {
   }
 
   /// SIMPLE GETTERS
-  get isLoading => _isLoading;
-  get error => _error;
-  get lastUpdated => _lastUpdated;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  DateTime? get lastUpdated => _lastUpdated;
   List<AvailabilityModel> get data => _data;
 }


### PR DESCRIPTION
## Summary
Removed markets from the Busyness card (for now) since the backend is malfunctioning and not returning any data for it to display.


## Changelog
- Added patch so that the markets data is deliberately ignored from the JSON API response and not displayed in the card
- Tidied up the code and slightly improved readability
- Added notes for how to undo this patch once backend is fixed


## Test Plan
[PR-2108-Test-Plan-7.30.0-QA-3404.xlsx (Android)](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7BE52946A9-C14C-47EA-BD09-BE4420FD5D9D%7D&file=PR-2108-Test-Plan-7.30.0-QA-3404.xlsx&action=default&mobileredirect=true)
[PR-2108-Test-Plan-7.30.0-QA-3404.xlsx (iOS)](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7BC32037BE-AF2A-44FD-A8E6-471F3BB9393B%7D&file=PR-2108-Test-Plan-7.30.0-QA-3403.xlsx&action=default&mobileredirect=true)


