### PR TITLE
finished finals layout

### DIFF
--- a/lib/ui/common/last_updated_widget.dart
+++ b/lib/ui/common/last_updated_widget.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
+import '../../app_styles.dart';
 
 class LastUpdatedWidget extends StatelessWidget {
-  const LastUpdatedWidget({
-    Key? key,
-    required this.time,
-  }) : super(key: key);
+  const LastUpdatedWidget({Key? key, required this.time}) : super(key: key);
 
   /// STATES
   final DateTime time;
@@ -15,8 +13,12 @@ class LastUpdatedWidget extends StatelessWidget {
       child: Text(
         'Last updated: ' + determineText(time),
         style: TextStyle(
-            color: Colors.grey, fontStyle: FontStyle.italic, fontSize: 16),
-      ),
+            fontSize: 16.0,
+            fontStyle: FontStyle.italic,
+            fontWeight: FontWeight.w400,
+            color: descriptiveTextColorLight
+        )
+      )
     );
   }
 

--- a/lib/ui/finals/finals_card.dart
+++ b/lib/ui/finals/finals_card.dart
@@ -72,7 +72,7 @@ class FinalsCard extends StatelessWidget {
         for (SectionData data in value) {
           listToReturn.add(ListTile(
             // Friday
-            title: buildWeekdayText(abbrevToFullWeekday(data.days)),
+            title: buildWeekdayText(context, abbrevToFullWeekday(data.days)),
             subtitle: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -80,17 +80,17 @@ class FinalsCard extends StatelessWidget {
                 // CSE 127  19:00 - 21:59
                 Row(
                   children: [
-                    buildClassCode(data.subjectCode! + ' ' + data.courseCode!),
+                    buildClassCode(context, data.subjectCode! + ' ' + data.courseCode!),
                     SizedBox(width: 10), // 10 logical pixels
                     buildTimeRow(context, data.time),
                   ],
                 ),
                 SizedBox(height: 2),
                 // Intro to Computer Security
-                buildClassTitle(data.courseTitle!),
+                buildClassTitle(context, data.courseTitle!),
                 SizedBox(height: 2),
                 // WLH 2005
-                buildLocationRow(data.building! + ' ' + data.room!),
+                buildLocationRow(context, data.building! + ' ' + data.room!),
                 ///////////////// Horizontal Division ///////////////////
                 if(i < finalsCount)
                   Divider(color: listTileDividerColorLight, thickness: 0.7),
@@ -130,18 +130,21 @@ class FinalsCard extends StatelessWidget {
   }
 
   // Subheading i.e. "Monday"
-  Widget buildWeekdayText(String nextDayWithClasses) {
+  Widget buildWeekdayText(BuildContext context, String nextDayWithClasses) {
     return Text(
       nextDayWithClasses,
       style: TextStyle(
         fontSize: 24.0,
         fontWeight: FontWeight.w500,
+        color: Theme.of(context).brightness == Brightness.light
+            ? lightPrimaryColor
+            : darkPrimaryColor2,
       ),
     );
   }
 
   // Heading 3 i.e. "CSE 140"
-  Widget buildClassCode(String className) {
+  Widget buildClassCode(BuildContext context, String className) {
     return Text(
       className,
       style: TextStyle(
@@ -149,7 +152,9 @@ class FinalsCard extends StatelessWidget {
           fontFamily: 'Refrigerator Deluxe',
           fontWeight: FontWeight.w900,
           letterSpacing: 1.1,
-          color: lightPrimaryColor
+        color: Theme.of(context).brightness == Brightness.light
+            ? lightPrimaryColor
+            : darkPrimaryColor2,
       )
     );
   }
@@ -170,19 +175,21 @@ class FinalsCard extends StatelessWidget {
 
 
   // Medium Body text i.e. "Intro to Computer Security"
-  Widget buildClassTitle(String title) {
+  Widget buildClassTitle(BuildContext context, String title) {
     return Text(
         title,
       style: TextStyle(
           fontSize: 18.0,
-          fontWeight: FontWeight.w400,
-          color: descriptiveTextColorLight
+          color: Theme.of(context).brightness == Brightness.light
+              ? descriptiveTextColorLight
+              : descriptiveTextColorDark,
+          fontWeight: FontWeight.w400
       )
     );
   }
 
   // Medium Body Text i.e. "WLH 2005"
-  Widget buildLocationRow(String location) {
+  Widget buildLocationRow(BuildContext context, String location) {
     return Row(
       children: <Widget>[
         Flexible(
@@ -192,8 +199,10 @@ class FinalsCard extends StatelessWidget {
               Text(location,
                   style: TextStyle(
                       fontSize: 18.0,
-                      fontWeight: FontWeight.w400,
-                      color: descriptiveTextColorLight
+                      color: Theme.of(context).brightness == Brightness.light
+                          ? descriptiveTextColorLight
+                          : descriptiveTextColorDark,
+                      fontWeight: FontWeight.w400
                   )
               ),
             ],

--- a/lib/ui/finals/finals_card.dart
+++ b/lib/ui/finals/finals_card.dart
@@ -146,6 +146,7 @@ class FinalsCard extends StatelessWidget {
       className,
       style: TextStyle(
           fontSize: 18.0,
+          fontFamily: 'Refrigerator Deluxe',
           fontWeight: FontWeight.w900,
           letterSpacing: 0.8,
           color: lightPrimaryColor

--- a/lib/ui/finals/finals_card.dart
+++ b/lib/ui/finals/finals_card.dart
@@ -4,10 +4,10 @@ import 'package:campus_mobile_experimental/core/providers/cards.dart';
 import 'package:campus_mobile_experimental/core/providers/classes.dart';
 import 'package:campus_mobile_experimental/ui/common/card_container.dart';
 import 'package:campus_mobile_experimental/ui/common/last_updated_widget.dart';
-import 'package:campus_mobile_experimental/ui/common/time_range_widget.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../../app_styles.dart';
 
 const cardId = 'finals';
 
@@ -61,28 +61,48 @@ class FinalsCard extends StatelessWidget {
   Widget buildFinalsCard(Map<String, List<SectionData>> finalsData,
       DateTime lastUpdated, String? nextDayWithClasses, BuildContext context) {
     try {
+      var finalsCount = 0, i = 1;
+      // Iterate through the map and count the number Finals
+      finalsData.forEach((key, value) {
+        finalsCount += value.length;
+      });
+
       List<Widget> listToReturn = [];
       finalsData.forEach((key, value) {
         for (SectionData data in value) {
           listToReturn.add(ListTile(
+            // Friday
             title: buildWeekdayText(abbrevToFullWeekday(data.days)),
             subtitle: Column(
-              children: [
-                buildClassTitle(data.subjectCode! + ' ' + data.courseCode!),
-                buildTimeRow(data.time),
-                buildClassTitle(data.courseTitle!),
-                buildLocationRow(data.building! + ' ' + data.room!),
-              ],
               crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: 7),
+                // CSE 127  19:00 - 21:59
+                Row(
+                  children: [
+                    buildClassCode(data.subjectCode! + ' ' + data.courseCode!),
+                    SizedBox(width: 10), // 10 logical pixels
+                    buildTimeRow(context, data.time),
+                  ],
+                ),
+                SizedBox(height: 2),
+                // Intro to Computer Security
+                buildClassTitle(data.courseTitle!),
+                SizedBox(height: 2),
+                // WLH 2005
+                buildLocationRow(data.building! + ' ' + data.room!),
+                ///////////////// Horizontal Division ///////////////////
+                if(i < finalsCount)
+                  Divider(color: listTileDividerColorLight, thickness: 0.7),
+              ],
             ),
           ));
+          i++;
         }
       });
-      listToReturn =
-          ListTile.divideTiles(tiles: listToReturn, context: context).toList();
       listToReturn.add(
         Padding(
-          padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
+          padding: const EdgeInsets.only(left: 16.0, top: 22.0),
           child: LastUpdatedWidget(time: lastUpdated),
         ),
       );
@@ -98,7 +118,7 @@ class FinalsCard extends StatelessWidget {
         width: double.infinity,
         child: Center(
           child: Padding(
-            padding: EdgeInsets.only(top: 32, bottom: 48),
+            padding: EdgeInsets.only(left: 12,top: 32, bottom: 48),
             child: Container(
               child: Text(
                   "Your finals could not be displayed.\n\nIf the problem persists contact mobilesupport@ucsd.edu"),
@@ -109,41 +129,58 @@ class FinalsCard extends StatelessWidget {
     }
   }
 
-  Widget buildClassTitle(String title) {
-    return Text(title);
-  }
-
+  // Subheading i.e. "Monday"
   Widget buildWeekdayText(String nextDayWithClasses) {
     return Text(
       nextDayWithClasses,
-      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+      style: TextStyle(
+        fontSize: 24.0,
+        fontWeight: FontWeight.w500,
+      ),
     );
   }
 
+  // Heading 3 i.e. "CSE 140"
   Widget buildClassCode(String className) {
     return Text(
       className,
-      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+      style: TextStyle(
+          fontSize: 18.0,
+          fontWeight: FontWeight.w900,
+          letterSpacing: 0.8,
+          color: lightPrimaryColor
+      )
     );
   }
 
-  Widget buildTimeRow(String? time) {
-    return Row(
-      children: <Widget>[
-        Flexible(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              TimeRangeWidget(
-                time: time!,
-              ),
-            ],
-          ),
-        ),
-      ],
+  // Small body text i.e. 15:00 - 17:59 (24hr format)
+  Widget buildTimeRow(BuildContext context, String? time) {
+    return Text(
+      time ?? 'TBA', // TBA if time is null or empty
+      style: TextStyle(
+        fontSize: 16,
+        color: Theme.of(context).brightness == Brightness.light
+            ? descriptiveTextColorLight
+            : descriptiveTextColorDark,
+        fontWeight: FontWeight.w400,
+      ),
     );
   }
 
+
+  // Medium Body text i.e. "Intro to Computer Security"
+  Widget buildClassTitle(String title) {
+    return Text(
+        title,
+      style: TextStyle(
+          fontSize: 18.0,
+          fontWeight: FontWeight.w400,
+          color: descriptiveTextColorLight
+      )
+    );
+  }
+
+  // Medium Body Text i.e. "WLH 2005"
   Widget buildLocationRow(String location) {
     return Row(
       children: <Widget>[
@@ -151,7 +188,13 @@ class FinalsCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Text(location),
+              Text(location,
+                  style: TextStyle(
+                      fontSize: 18.0,
+                      fontWeight: FontWeight.w400,
+                      color: descriptiveTextColorLight
+                  )
+              ),
             ],
           ),
         ),

--- a/lib/ui/finals/finals_card.dart
+++ b/lib/ui/finals/finals_card.dart
@@ -148,7 +148,7 @@ class FinalsCard extends StatelessWidget {
           fontSize: 18.0,
           fontFamily: 'Refrigerator Deluxe',
           fontWeight: FontWeight.w900,
-          letterSpacing: 0.8,
+          letterSpacing: 1.1,
           color: lightPrimaryColor
       )
     );


### PR DESCRIPTION
## Summary
Redesigned the finals card to reflect the figma design.
![image](https://github.com/user-attachments/assets/1cf68236-404a-45d0-b025-4f5f94bd7c13)  
![image](https://github.com/user-attachments/assets/f63d6f78-cf52-4e70-88a4-ba3bfbd12863)


## Changelog
[General][Change] - Re-made the finals card layout.


## Test Plan
Ensure your finals are showing up properly.
No Overflow.
There should be N-1 horizontal divisions, N being the number of finals you have.

