### PR TITLE
Maps scaffold bug fix

### DIFF
--- a/lib/ui/map/directions_button.dart
+++ b/lib/ui/map/directions_button.dart
@@ -5,6 +5,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../app_styles.dart';
+
 class DirectionsButton extends StatelessWidget {
   const DirectionsButton({
     Key? key,
@@ -34,7 +36,10 @@ class DirectionsButton extends StatelessWidget {
                 null) {
           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
             content: Text(
-                'Please turn your location on in order to use this feature.'),
+              'Please turn your location on in order to use this feature.',
+              style: TextStyle(color: Colors.white),
+            ),
+            backgroundColor: darkPrimaryColor,
             duration: Duration(seconds: 3),
           ));
         } else {

--- a/lib/ui/map/directions_button.dart
+++ b/lib/ui/map/directions_button.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
-
 import '../../app_styles.dart';
 
 class DirectionsButton extends StatelessWidget {

--- a/lib/ui/map/my_location_button.dart
+++ b/lib/ui/map/my_location_button.dart
@@ -2,7 +2,6 @@ import 'package:campus_mobile_experimental/core/providers/map.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';
-
 import '../../app_styles.dart';
 
 class MyLocationButton extends StatelessWidget {

--- a/lib/ui/map/my_location_button.dart
+++ b/lib/ui/map/my_location_button.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';
 
+import '../../app_styles.dart';
+
 class MyLocationButton extends StatelessWidget {
   const MyLocationButton({
     Key? key,
@@ -32,7 +34,10 @@ class MyLocationButton extends StatelessWidget {
                 null) {
           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
             content: Text(
-                'Please turn your location on in order to use this feature.'),
+              'Please turn your location on in order to use this feature.',
+              style: TextStyle(color: Colors.white),
+            ),
+            backgroundColor: darkPrimaryColor,
             duration: Duration(seconds: 3),
           ));
         } else {


### PR DESCRIPTION
## Summary
Fixed UI bug where the map scaffold's error message was not displaying correctly in dark theme when location services were disabled.

Before fix:  
![image](https://github.com/user-attachments/assets/b5ad1d99-5760-4fd6-8167-c821713c341f)

After fix:  
![image](https://github.com/user-attachments/assets/a17209fe-2e80-4b4e-a0c4-6b05c660568e)


## Changelog
[General] [Fix] - Message is now visible in dark theme.

## Test Plan
Don't allow access to location, set your phone in dark theme, and click both the Directions and Location buttons inside the Map screen to see the message "Please turn your location on in order to use this feature."

