### PR TITLE
Update analysis_options.yaml to expand maximum line length for the Dart formatter

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+formatter:
+  page_width: 120


### PR DESCRIPTION
## Summary
Updates the analysis_options.yaml file for Dart's formatter


## Changelog
- Expanded page_width (line length) from 80 to 120


## Test Plan
No testing required. No code changes were performed.