### PR TITLE
(CAAPP-311 ) UI Update - Dining (CAAPP-326)

### DIFF
--- a/lib/ui/common/time_range_widget.dart
+++ b/lib/ui/common/time_range_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-
 import 'package:campus_mobile_experimental/app_styles.dart';
 
 /// This object takes a String that represents a time range in 24 hour format

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -48,13 +48,19 @@ class DiningDetailView extends StatelessWidget {
         'Location',
         style: Theme.of(context).textTheme.titleMedium,
       ),
-      buildDirectionsButton(context, model),
-      Row(
-        children: [
-          buildWebsiteButton(context, model),
-          SizedBox(width: 15),
-          buildMenuButton(context, model),
-        ],
+      Transform.translate(
+        offset: const Offset(0, -15),
+        child: buildDirectionsButton(context, model),
+      ),
+      Transform.translate(
+        offset: const Offset(0, -12),
+        child: Row(
+          children: [
+            buildWebsiteButton(context, model),
+            SizedBox(width: 15),
+            buildMenuButton(context, model),
+          ],
+        ),
       ),
       // TODO: removed the menu on March 25, 2025
       //SizedBox(height: 20),
@@ -72,13 +78,14 @@ class DiningDetailView extends StatelessWidget {
           children: <Widget>[
             Text(
               'Get Directions',
-              style: linkTextDark.copyWith(fontSize: 14.0),
+              style: linkTextDark.copyWith(fontSize: 18.0),
             ),
             Row(
               children: <Widget>[
                 Icon(
                   Icons.directions_walk,
-                  color: Theme.of(context).iconTheme.color,
+                  color: linkColorLight,
+                  size: 32,
                 ),
                 model.distance != null
                     ? Text(
@@ -86,9 +93,10 @@ class DiningDetailView extends StatelessWidget {
                                 .toString() +
                             ' mi',
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              fontSize: 14.0,
+                              fontSize: 18.0,
+                              color: linkColorLight, 
                             ))
-                    : Text('--'),
+                    : Text('--', style: TextStyle(color: linkColorLight)),
               ],
             ),
           ],
@@ -357,7 +365,7 @@ class HoursOfDay extends StatelessWidget {
                       : Container(width: 10),
                   SizedBox(width: 5),
                   Text(
-                    '$theDay: ',
+                    '$theDay ',
                     style: weekday == DateTime.now().weekday
                         ? Theme.of(context)
                             .textTheme
@@ -383,17 +391,31 @@ class HoursOfDay extends StatelessWidget {
                                   ?.copyWith(fontWeight: FontWeight.bold)
                               : Theme.of(context).textTheme.bodySmall,
                         )
-                      : TimeRangeWidget(
-                          time: theHours
-                              .replaceAllMapped(
-                                  //Add colon in between each time
-                                  RegExp(r"\b[0-9]{2}"),
-                                  (match) => "${match.group(0)}:")
-                              .replaceAllMapped(
-                                  //Add space around hyphen
-                                  RegExp(r"-"),
-                                  (match) => " ${match.group(0)} "),
-                        ),
+                      : (weekday == DateTime.now().weekday
+                          ? DefaultTextStyle(
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall!
+                                  .copyWith(fontWeight: FontWeight.bold),
+                              child: TimeRangeWidget(
+                                time: theHours
+                                    .replaceAllMapped(
+                                        RegExp(r"\b[0-9]{2}"),
+                                        (match) => "${match.group(0)}:")
+                                    .replaceAllMapped(
+                                        RegExp(r"-"),
+                                        (match) => " ${match.group(0)} "),
+                              ),
+                            )
+                          : TimeRangeWidget(
+                              time: theHours
+                                  .replaceAllMapped(
+                                      RegExp(r"\b[0-9]{2}"),
+                                      (match) => "${match.group(0)}:")
+                                  .replaceAllMapped(
+                                      RegExp(r"-"),
+                                      (match) => " ${match.group(0)} "),
+                            )),
                 ],
               ),
             ),

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -55,9 +55,13 @@ class DiningList extends StatelessWidget {
         : ContainerView(
             child: ListView(
               padding: const EdgeInsets.only(left: 16, right: 16),
-              children:
-                  ListTile.divideTiles(tiles: diningTiles, context: context)
-                      .toList(),
+              children: ListTile.divideTiles(
+                tiles: diningTiles,
+                context: context,
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? listTileDividerColorDark
+                    : listTileDividerColorLight,
+              ).toList(),
             ),
           );
   }
@@ -164,7 +168,7 @@ class DiningList extends StatelessWidget {
   Widget buildIconWithDistance(DiningModel data, BuildContext context) {
     return TextButton(
       style: TextButton.styleFrom(
-        foregroundColor: Theme.of(context).colorScheme.background,
+        foregroundColor: linkColorLight, 
       ),
       onPressed: () {
         try {
@@ -181,6 +185,7 @@ class DiningList extends StatelessWidget {
           Icon(
             Icons.directions_walk,
             size: 28,
+            color: linkColorLight, 
           ),
           SizedBox(
               height:
@@ -190,7 +195,7 @@ class DiningList extends StatelessWidget {
                 ? (num.parse(data.distance!.toStringAsFixed(1)).toString() +
                     ' mi')
                 : '--',
-            style: TextStyle(fontSize: 12),
+            style: TextStyle(fontSize: 12, color: linkColorLight), 
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- Homescreen card & Individual Dining Screen: Changed icon and distance text color to match Figma Design
- “View All Dining Options”: added Divider between dining options list
- Individual Dining Screen: fixed bold for current hours, removed colons from days of week, changed-increased “Get Directions”, icon and distance text size, adjusted (customized) empty space between “Location” and “Get Directions” to match Figma design as well as empty space between “Get Directions” and “Visit Website”
Note: the broken “Visit Website” and “View Menu” links are broken due to content issue!

## Changelog
[General] [Change] - increased size of icon, distance text, “Get Directions” 
[General] [Fix] - bold for current hours
[General] [Remove] - colons “:” from Days of the week
[General] [Add] - Divider in dining list options
[General] [Add] - customized empty space between “Location” and “Get Directions” and “Get Directions” and “Visit Website”


## Test Plan


[PR 2176 Test Plan - 7.31.0 - IOS - QA](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B2216E8EC-53DD-4DFD-926A-DA64A4691524%7D&file=PR-2176-Test-Plan-7.31.0-QA-3831.xlsx&action=default&mobileredirect=true)

[PR 2176 Test Plan - 7.31.0 - Android - QA](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7BC846B532-CC7A-410B-8DCC-7BFBEDB836A3%7D&file=PR-2176-Test-Plan-7.31.0-QA-3832.xlsx&action=default&mobileredirect=true)


Ran simulator for both Android and iPhone on Android Studio

<img width="349" alt="before1" src="https://github.com/user-attachments/assets/e6c6567b-f323-47ea-b12c-17111acda066" />
<img width="350" alt="before2" src="https://github.com/user-attachments/assets/1130110e-1915-40b9-b1de-c9020ebeba8b" />
<img width="348" alt="before3" src="https://github.com/user-attachments/assets/603669df-9dbc-4976-bb8c-6aa500461527" />
<img width="383" alt="after1" src="https://github.com/user-attachments/assets/e2b3e912-f455-4571-a76a-9104902f9b3e" />
<img width="284" alt="after2" src="https://github.com/user-attachments/assets/09271878-d79d-4303-a673-4184708a00d3" />
<img width="336" alt="after3" src="https://github.com/user-attachments/assets/ed258f5a-1b3b-418d-9cbf-0aee0195d33c" />
