### PR TITLE
(CAAPP-311 ) UI Update - Parking (CAAPP-325) 

### DIFF
--- a/lib/ui/parking/manage_parking_view.dart
+++ b/lib/ui/parking/manage_parking_view.dart
@@ -50,13 +50,22 @@ class _ManageParkingViewState extends State<ManageParkingView> {
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
       child: ListView(
         shrinkWrap: true,
-        children: ListTile.divideTiles(
-          tiles: listTiles,
-          context: context,
-          color: Theme.of(context).brightness == Brightness.dark
-              ? listTileDividerColorDark
-              : listTileDividerColorLight,
-        ).toList(),
+        children: [
+          for (int i = 0; i < listTiles.length; i++) ...[
+            listTiles[i],
+            if (i != listTiles.length - 1)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: Divider(
+                  color: Theme.of(context).brightness == Brightness.dark
+                      ? listTileDividerColorDark
+                      : listTileDividerColorLight,
+                  thickness: 0.5,
+                  height: 0,
+                ),
+              ),
+          ]
+        ],
       ),
     );
   }

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -97,21 +97,7 @@ class _ParkingCardState extends State<ParkingCard> {
                 });
               },
               itemBuilder: (context, index) {
-                return AnimatedBuilder(
-                  animation: _controller,
-                  builder: (context, child) {
-                    double value = 1.0;
-                    if (_controller.position.haveDimensions) {
-                      value = ((_controller.page ?? _controller.initialPage) - index).toDouble();
-                      value = (1 - (value.abs() * 0.5)).clamp(0.5, 1.0);
-                    }
-                    return Transform.scale(
-                      scale: value,
-                      child: child,
-                    );
-                  },
-                  child: selectedLotsViews[index],
-                );
+                return selectedLotsViews[index];
               },
             ),
           ),

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -21,7 +21,7 @@ class _ParkingCardState extends State<ParkingCard> {
 
   late ParkingDataProvider _parkingDataProvider;
 
-  final _controller = PageController();
+  final _controller = PageController(viewportFraction: 0.92);
   int _currentPage = 0;
 
   @override
@@ -87,14 +87,32 @@ class _ParkingCardState extends State<ParkingCard> {
       return Column(
         children: <Widget>[
           Expanded(
-            child: PageView(
+            child: PageView.builder(
               controller: _controller,
+              itemCount: selectedLotsViews.length,
+              physics: BouncingScrollPhysics(),
               onPageChanged: (index) {
                 setState(() {
                   _currentPage = index;
                 });
               },
-              children: selectedLotsViews,
+              itemBuilder: (context, index) {
+                return AnimatedBuilder(
+                  animation: _controller,
+                  builder: (context, child) {
+                    double value = 1.0;
+                    if (_controller.position.haveDimensions) {
+                      value = ((_controller.page ?? _controller.initialPage) - index).toDouble();
+                      value = (1 - (value.abs() * 0.5)).clamp(0.5, 1.0);
+                    }
+                    return Transform.scale(
+                      scale: value,
+                      child: child,
+                    );
+                  },
+                  child: selectedLotsViews[index],
+                );
+              },
             ),
           ),
           DotsIndicator(

--- a/lib/ui/parking/parking_structure_view.dart
+++ b/lib/ui/parking/parking_structure_view.dart
@@ -30,8 +30,9 @@ class _ParkingStructureViewState extends State<ParkingStructureView> {
     List<Widget> listTiles = [];
     listTiles.add(
       ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
         title: Padding(
-          padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
+          padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
           child: Text("Parking Structures",
               style: Theme.of(context).brightness == Brightness.dark
                   ? textSubheaderDark
@@ -50,8 +51,9 @@ class _ParkingStructureViewState extends State<ParkingStructureView> {
           parkingDataProvider.parkingViewState[structureName]!;
       listTiles.add(
         ListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
           title: Padding(
-            padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
+            padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
             child: Text(
               structureName,
               style: Theme.of(context).textTheme.bodyMedium,
@@ -93,13 +95,22 @@ class _ParkingStructureViewState extends State<ParkingStructureView> {
     return ListView(
       physics: BouncingScrollPhysics(),
       shrinkWrap: true,
-      children: ListTile.divideTiles(
-        tiles: listTiles,
-        context: context,
-        color: Theme.of(context).brightness == Brightness.dark
-            ? listTileDividerColorDark
-            : listTileDividerColorLight,
-      ).toList(),
+      children: [
+        for (int i = 0; i < listTiles.length; i++) ...[
+          listTiles[i],
+          if (i != listTiles.length - 1)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Divider(
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? listTileDividerColorDark
+                    : listTileDividerColorLight,
+                thickness: 0.5,
+                height: 0,
+              ),
+            ),
+        ]
+      ],
     );
   }
 }

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -26,13 +26,22 @@ class _SpotTypesViewState extends State<SpotTypesView> {
   Widget createListWidget(BuildContext context) => Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8.0),
         child: ListView(
-          children: ListTile.divideTiles(
-            tiles: createList(context),
-            context: context,
-            color: Theme.of(context).brightness == Brightness.dark
-                ? listTileDividerColorDark
-                : listTileDividerColorLight,
-          ).toList(),
+          children: [
+            for (int i = 0; i < createList(context).length; i++) ...[
+              createList(context)[i],
+              if (i != createList(context).length - 1)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Divider(
+                    color: Theme.of(context).brightness == Brightness.dark
+                        ? listTileDividerColorDark
+                        : listTileDividerColorLight,
+                    thickness: 1,
+                    height: 0,
+                  ),
+                ),
+            ]
+          ],
         ),
       );
 


### PR DESCRIPTION
## Summary
implemented a smooth scale transition effect for the slider using PageView.builder, viewportFraction, and Transform.scale, and refactored custom dividers to use divider widgets to fix the “parking structures” dividers issue


## Changelog
[General] [Add] - smooth scale transition effect for the slider control
[General] [Change] - implemented divider widget for dividers issue


## Test Plan
Ran simulator for both Android and iPhone on Android Studio
![before1](https://github.com/user-attachments/assets/55cb94f9-6ce9-4399-aa11-88ec03bd44bb)
<img width="317" alt="after1" src="https://github.com/user-attachments/assets/3cc5edba-de4c-45e5-a76d-8981e7f1afd2" />
<img width="357" alt="before2" src="https://github.com/user-attachments/assets/d7a2be28-a771-466c-90b6-d18c8d94fb81" />
<img width="355" alt="after2" src="https://github.com/user-attachments/assets/ec0d26fe-ef49-4c93-8f6e-c95ede847a4b" />


