### PR TITLE
Increased size of "tap for easier scanning"

### DIFF
--- a/lib/ui/student_id/student_id_card.dart
+++ b/lib/ui/student_id/student_id_card.dart
@@ -264,7 +264,7 @@ class _StudentIdCardState extends State<StudentIdCard> {
             style: TextStyle(
               fontWeight: FontWeight.bold,
               decoration: TextDecoration.underline,
-              fontSize: ScalingUtility.horizontalSafeBlock * 2.5,
+              fontSize: ScalingUtility.horizontalSafeBlock * 3.8,
               color: Theme.of(context).brightness == Brightness.dark
                   ? linkColorDark
                   : linkColorLight,


### PR DESCRIPTION
## Summary
Increased the size of "tap for easier scanning" message to a height of 17 pixels in the Student ID card to reflect the Figma design.  

Figma:  
![image](https://github.com/user-attachments/assets/09fec0e1-0fba-4881-9148-68a12666f7cd)

App:  
![Screenshot_20250613-205910](https://github.com/user-attachments/assets/06d6228e-6a36-4b90-ac27-4e4a59236050)

## Changelog
[General] [Change] - Changed factor by which the font size was increased from 2.5 to 3.8.

## Test Plan
Student ID should display a "tap for easier scanning" text with a bigger font size.