### PR TITLE
Dining margin fix - CAAPP-379

### DIFF
--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -9,97 +9,6 @@ import '../../core/models/availability.dart';
 import '../../core/providers/availability.dart';
 import 'dining_busyness_bar.dart';
 
-int _currDay = -1;
-String _currHours = '';
-class GreenDot extends StatelessWidget {
-  const GreenDot({Key? key, required this.currHours}) : super(key: key);
-  final String currHours;
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 8,
-      height: 8,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: _determineColor(),
-      ),
-    );
-  }
-
-  Color _determineColor() {
-    // Handle special cases like "Closed" or "Open 24/7"
-    if (currHours == 'Closed') {
-      return Colors.red;
-    } else if (currHours == 'Open 24/7') {
-      return Colors.green;
-    }
-
-    // If this is a time range like "9:00 AM - 5:00 PM"
-    if (currHours.contains('-')) {
-      try {
-        final timeStrings = currHours.split('-');
-        if (timeStrings.length != 2) {
-          return Colors.grey; // Invalid format
-        }
-
-        // Parse the start and end times
-        final now = TimeOfDay.now();
-        final currentTimeInMinutes = now.hour * 60 + now.minute;
-
-        // Parse start time (e.g. "9:00 AM")
-        final startTime = _parseTimeString(timeStrings[0].trim());
-        if (startTime == null) return Colors.grey;
-
-        // Parse end time (e.g. "5:00 PM")
-        final endTime = _parseTimeString(timeStrings[1].trim());
-        if (endTime == null) return Colors.grey;
-
-        // Adjust for overnight hours
-        int adjustedEndTime = endTime;
-        if (endTime < startTime) {
-          adjustedEndTime += 24 * 60; // Add a day in minutes
-        }
-
-        // Determine if current time is within the range
-        if (currentTimeInMinutes >= startTime &&
-            currentTimeInMinutes < adjustedEndTime) {
-          return Colors.green;
-        } else {
-          return Colors.red;
-        }
-      } catch (e) {
-        print('Error parsing time: $e');
-        return Colors.grey; // Error in parsing
-      }
-    }
-    return Colors.grey; // Default color for unrecognized format
-  }
-
-  // Parse time strings like "9:00 AM" into minutes since midnight
-  int? _parseTimeString(String timeString) {
-    // Try to extract the hour, minute, and AM/PM parts
-    final amPmRegex = RegExp(r'(\d+):(\d+)\s*(AM|PM)');
-    final match = amPmRegex.firstMatch(timeString);
-
-    if (match != null && match.groupCount >= 3) {
-      int hour = int.parse(match.group(1)!);
-      final int minute = int.parse(match.group(2)!);
-      final String amPm = match.group(3)!.toUpperCase();
-
-      // Convert 12-hour to 24-hour format
-      if (amPm == 'PM' && hour < 12) {
-        hour += 12;
-      } else if (amPm == 'AM' && hour == 12) {
-        hour = 0;
-      }
-
-      return hour * 60 + minute;
-    }
-
-    return null;
-  }
-}
-
 class DiningDetailView extends StatefulWidget {
   const DiningDetailView({Key? key, required this.data}) : super(key: key);
   final prefix0.DiningModel data;
@@ -195,25 +104,22 @@ class _DiningDetailViewState extends State<DiningDetailView> {
       ),
       // Availability Bars if applicable (Canyon Vista, Club Med, Pines, 64 Degrees, Cafe Ventanas)
       if ((busynessDiningHallModelOne != null &&
-                busynessDiningHallModelOne.subLocations.any(
-                    (child) =>
-                        child.name.contains(diningModel.name) ||
-                        diningModel.name.contains(child.name))) ||
-            (busynessDiningHallModelTwo != null &&
-                busynessDiningHallModelTwo.subLocations.any(
-                    (child) =>
-                        child.name.contains(diningModel.name) ||
-                        diningModel.name.contains(child.name))))
-          DiningBusynessBar(
-            diningModel: diningModel,
-            busynessDiningHallModel: (busynessDiningHallModelOne != null &&
-                    busynessDiningHallModelOne.subLocations.any(
-                        (child) =>
-                            child.name.contains(diningModel.name) ||
-                            diningModel.name.contains(child.name)))
-                ? busynessDiningHallModelOne
-                : busynessDiningHallModelTwo!,
-          ),
+              busynessDiningHallModelOne.subLocations.any((child) =>
+                  child.name.contains(diningModel.name) ||
+                  diningModel.name.contains(child.name))) ||
+          (busynessDiningHallModelTwo != null &&
+              busynessDiningHallModelTwo.subLocations.any((child) =>
+                  child.name.contains(diningModel.name) ||
+                  diningModel.name.contains(child.name))))
+        DiningBusynessBar(
+          diningModel: diningModel,
+          busynessDiningHallModel: (busynessDiningHallModelOne != null &&
+                  busynessDiningHallModelOne.subLocations.any((child) =>
+                      child.name.contains(diningModel.name) ||
+                      diningModel.name.contains(child.name)))
+              ? busynessDiningHallModelOne
+              : busynessDiningHallModelTwo!,
+        ),
       // Vendor hours
       buildHours(context, diningModel),
       // Vendor Special Hours
@@ -255,10 +161,12 @@ class _DiningDetailViewState extends State<DiningDetailView> {
         style: Theme.of(context).textTheme.titleMedium,
       ),
       SizedBox(height: 8),
-      ...List.generate(7, (i) => [
-            HoursOfDay(day: i + 1, model: model),
-            if (i < 6) buildDivider(context),
-          ]).expand((widgetPair) => widgetPair).toList(),
+      ...List.generate(
+          7,
+          (i) => [
+                HoursOfDay(day: i + 1, model: model),
+                if (i < 6) buildDivider(context),
+              ]).expand((widgetPair) => widgetPair).toList(),
       SizedBox(height: 16),
     ]);
   }
@@ -499,8 +407,7 @@ class HoursOfDay extends StatelessWidget {
 
     // Check if this is the current day
     final bool isToday = day == DateTime.now().weekday;
-    return Column(crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
@@ -555,63 +462,137 @@ Map<String, String> extractDayHours(int day, prefix0.DiningModel? model) {
   switch (day) {
     case 1:
       theDay = 'Monday';
-      theHours = model!.regularHours.mon == null
-          ? 'Closed'
-          : model.regularHours.mon;
+      theHours =
+          model!.regularHours.mon == null ? 'Closed' : model.regularHours.mon;
       break;
     case 2:
       theDay = 'Tuesday';
-      theHours = model!.regularHours.tue == null
-          ? 'Closed'
-          : model.regularHours.tue;
+      theHours =
+          model!.regularHours.tue == null ? 'Closed' : model.regularHours.tue;
       break;
     case 3:
       theDay = 'Wednesday';
-      theHours = model!.regularHours.wed == null
-          ? 'Closed'
-          : model.regularHours.wed;
+      theHours =
+          model!.regularHours.wed == null ? 'Closed' : model.regularHours.wed;
       break;
     case 4:
       theDay = 'Thursday';
-      theHours = model!.regularHours.thu == null
-          ? 'Closed'
-          : model.regularHours.thu;
+      theHours =
+          model!.regularHours.thu == null ? 'Closed' : model.regularHours.thu;
       break;
     case 5:
       theDay = 'Friday';
-      theHours = model!.regularHours.fri == null
-          ? 'Closed'
-          : model.regularHours.fri;
+      theHours =
+          model!.regularHours.fri == null ? 'Closed' : model.regularHours.fri;
       break;
     case 6:
       theDay = 'Saturday';
-      theHours = model!.regularHours.sat == null
-          ? 'Closed'
-          : model.regularHours.sat;
+      theHours =
+          model!.regularHours.sat == null ? 'Closed' : model.regularHours.sat;
       break;
     case 7:
       theDay = 'Sunday';
-      theHours = model!.regularHours.sun == null
-          ? 'Closed'
-          : model.regularHours.sun;
+      theHours =
+          model!.regularHours.sun == null ? 'Closed' : model.regularHours.sun;
       break;
   }
 
-  /*As of 05/05/2020, API may return 'Closed-Closed' as a value. If it does,
-    correct it to look right.*/
+  /*As of 05/05/2020, API may return 'Closed-Closed' as a value. If it does, correct it to look right.*/
   if (theHours == 'Closed-Closed') theHours = 'Closed';
   // Determine the hours' text
-  final String hoursText =
-  (theHours != null && theHours.contains('Closed')) ||
-      theHours == 'Open 24/7'
+  final String hoursText = (theHours != null && theHours.contains('Closed')) ||
+          theHours == 'Open 24/7'
       ? theHours!
       : (formattedTimeRange(theHours) ?? theHours!);
 
-  // For tracking the current day
-  if (day == DateTime.now().weekday) {
-    _currDay = day;
-    _currHours = hoursText;
+  return {'day': theDay, 'hours': hoursText};
+}
+
+class GreenDot extends StatelessWidget {
+  const GreenDot({Key? key, required this.currHours}) : super(key: key);
+  final String currHours;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: _determineColor(),
+      ),
+    );
   }
 
-  return {'day': theDay, 'hours': hoursText};
+  Color _determineColor() {
+    // Handle special cases like "Closed" or "Open 24/7"
+    if (currHours == 'Closed') {
+      return Colors.red;
+    } else if (currHours == 'Open 24/7') {
+      return Colors.green;
+    }
+
+    // If this is a time range like "9:00 AM - 5:00 PM"
+    if (currHours.contains('-')) {
+      try {
+        final timeStrings = currHours.split('-');
+        if (timeStrings.length != 2) {
+          return Colors.grey; // Invalid format
+        }
+
+        // Parse the start and end times
+        final now = TimeOfDay.now();
+        final currentTimeInMinutes = now.hour * 60 + now.minute;
+
+        // Parse start time (e.g. "9:00 AM")
+        final startTime = _parseTimeString(timeStrings[0].trim());
+        if (startTime == null) return Colors.grey;
+
+        // Parse end time (e.g. "5:00 PM")
+        final endTime = _parseTimeString(timeStrings[1].trim());
+        if (endTime == null) return Colors.grey;
+
+        // Adjust for overnight hours
+        int adjustedEndTime = endTime;
+        if (endTime < startTime) {
+          adjustedEndTime += 24 * 60; // Add a day in minutes
+        }
+
+        // Determine if current time is within the range
+        if (currentTimeInMinutes >= startTime &&
+            currentTimeInMinutes < adjustedEndTime) {
+          return Colors.green;
+        } else {
+          return Colors.red;
+        }
+      } catch (e) {
+        print('Error parsing time: $e');
+        return Colors.grey; // Error in parsing
+      }
+    }
+    return Colors.grey; // Default color for unrecognized format
+  }
+
+  // Parse time strings like "9:00 AM" into minutes since midnight
+  int? _parseTimeString(String timeString) {
+    // Try to extract the hour, minute, and AM/PM parts
+    final amPmRegex = RegExp(r'(\d+):(\d+)\s*(AM|PM)');
+    final match = amPmRegex.firstMatch(timeString);
+
+    if (match != null && match.groupCount >= 3) {
+      int hour = int.parse(match.group(1)!);
+      final int minute = int.parse(match.group(2)!);
+      final String amPm = match.group(3)!.toUpperCase();
+
+      // Convert 12-hour to 24-hour format
+      if (amPm == 'PM' && hour < 12) {
+        hour += 12;
+      } else if (amPm == 'AM' && hour == 12) {
+        hour = 0;
+      }
+
+      return hour * 60 + minute;
+    }
+
+    return null;
+  }
 }

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -72,7 +72,6 @@ class GreenDot extends StatelessWidget {
         return Colors.grey; // Error in parsing
       }
     }
-
     return Colors.grey; // Default color for unrecognized format
   }
 

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -1,6 +1,5 @@
 import 'package:campus_mobile_experimental/core/models/dining.dart' as prefix0;
 import 'package:campus_mobile_experimental/ui/common/container_view.dart';
-import 'package:campus_mobile_experimental/ui/dining/dining_menu_list.dart';
 import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:campus_mobile_experimental/ui/common/time_range_widget.dart';
@@ -10,7 +9,98 @@ import '../../core/models/availability.dart';
 import '../../core/providers/availability.dart';
 import 'dining_busyness_bar.dart';
 
-late final int _currDay;
+int _currDay = -1;
+String _currHours = '';
+class GreenDot extends StatelessWidget {
+  const GreenDot({Key? key, required this.currHours}) : super(key: key);
+  final String currHours;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: _determineColor(),
+      ),
+    );
+  }
+
+  Color _determineColor() {
+    // Handle special cases like "Closed" or "Open 24/7"
+    if (currHours == 'Closed') {
+      return Colors.red;
+    } else if (currHours == 'Open 24/7') {
+      return Colors.green;
+    }
+
+    // If this is a time range like "9:00 AM - 5:00 PM"
+    if (currHours.contains('-')) {
+      try {
+        final timeStrings = currHours.split('-');
+        if (timeStrings.length != 2) {
+          return Colors.grey; // Invalid format
+        }
+
+        // Parse the start and end times
+        final now = TimeOfDay.now();
+        final currentTimeInMinutes = now.hour * 60 + now.minute;
+
+        // Parse start time (e.g. "9:00 AM")
+        final startTime = _parseTimeString(timeStrings[0].trim());
+        if (startTime == null) return Colors.grey;
+
+        // Parse end time (e.g. "5:00 PM")
+        final endTime = _parseTimeString(timeStrings[1].trim());
+        if (endTime == null) return Colors.grey;
+
+        // Adjust for overnight hours
+        int adjustedEndTime = endTime;
+        if (endTime < startTime) {
+          adjustedEndTime += 24 * 60; // Add a day in minutes
+        }
+
+        // Determine if current time is within the range
+        if (currentTimeInMinutes >= startTime &&
+            currentTimeInMinutes < adjustedEndTime) {
+          return Colors.green;
+        } else {
+          return Colors.red;
+        }
+      } catch (e) {
+        print('Error parsing time: $e');
+        return Colors.grey; // Error in parsing
+      }
+    }
+
+    return Colors.grey; // Default color for unrecognized format
+  }
+
+  // Parse time strings like "9:00 AM" into minutes since midnight
+  int? _parseTimeString(String timeString) {
+    // Try to extract the hour, minute, and AM/PM parts
+    final amPmRegex = RegExp(r'(\d+):(\d+)\s*(AM|PM)');
+    final match = amPmRegex.firstMatch(timeString);
+
+    if (match != null && match.groupCount >= 3) {
+      int hour = int.parse(match.group(1)!);
+      final int minute = int.parse(match.group(2)!);
+      final String amPm = match.group(3)!.toUpperCase();
+
+      // Convert 12-hour to 24-hour format
+      if (amPm == 'PM' && hour < 12) {
+        hour += 12;
+      } else if (amPm == 'AM' && hour == 12) {
+        hour = 0;
+      }
+
+      return hour * 60 + minute;
+    }
+
+    return null;
+  }
+}
+
 class DiningDetailView extends StatefulWidget {
   const DiningDetailView({Key? key, required this.data}) : super(key: key);
   final prefix0.DiningModel data;
@@ -157,7 +247,7 @@ class _DiningDetailViewState extends State<DiningDetailView> {
     ];
   }
 
-  ///////////// Hours and Special Hours Section /////////////
+  ///////////// Hours Section /////////////
   Widget buildHours(BuildContext context, prefix0.DiningModel model) {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       SizedBox(height: 14),
@@ -166,19 +256,10 @@ class _DiningDetailViewState extends State<DiningDetailView> {
         style: Theme.of(context).textTheme.titleMedium,
       ),
       SizedBox(height: 8),
-      HoursOfDay(day: 1, model: model),
-      buildDivider(context),
-      HoursOfDay(day: 2, model: model),
-      buildDivider(context),
-      HoursOfDay(day: 3, model: model),
-      buildDivider(context),
-      HoursOfDay(day: 4, model: model),
-      buildDivider(context),
-      HoursOfDay(day: 5, model: model),
-      buildDivider(context),
-      HoursOfDay(day: 6, model: model),
-      buildDivider(context),
-      HoursOfDay(day: 7, model: model),
+      ...List.generate(7, (i) => [
+            HoursOfDay(day: i + 1, model: model),
+            if (i < 6) buildDivider(context),
+          ]).expand((widgetPair) => widgetPair).toList(),
       SizedBox(height: 16),
     ]);
   }
@@ -192,6 +273,7 @@ class _DiningDetailViewState extends State<DiningDetailView> {
     );
   }
 
+  ///////////// Special Hours Section /////////////
   Widget buildSpecialHours(BuildContext context, prefix0.DiningModel model) {
     var specialHoursDuration = "";
     if (model.specialHours?.specialHoursValidFrom != null &&
@@ -415,7 +497,9 @@ class HoursOfDay extends StatelessWidget {
                 ? lightPrimaryColor
                 : darkPrimaryColor2)
         : Theme.of(context).textTheme.bodySmall!;
-    // Display the given day and hours in a row, if the given day is today, add a green dot
+
+    // Check if this is the current day
+    final bool isToday = day == DateTime.now().weekday;
     return Column(crossAxisAlignment: CrossAxisAlignment.start,
         children: [
       Row(
@@ -425,10 +509,15 @@ class HoursOfDay extends StatelessWidget {
             flex: 3,
             child: Row(
               children: [
+                // Show the green dot for today
+                if (isToday) ...[
+                  GreenDot(currHours: hoursText!),
+                  SizedBox(width: 5),
+                ],
                 // "Monday" - Bold if today is Monday.
                 Text(
                   '$theDay',
-                  style: day == DateTime.now().weekday
+                  style: isToday
                       ? TextStyle(
                           fontSize: 17.0,
                           fontWeight: FontWeight.w700,
@@ -519,46 +608,11 @@ Map<String, String> extractDayHours(int day, prefix0.DiningModel? model) {
       ? theHours!
       : (formattedTimeRange(theHours) ?? theHours!);
 
-  return {'day': theDay, 'hours': hoursText};
-}
-
-Widget buildGreenDot(String hours) {
-  MaterialColor color;
-  if (RegExp(r"\b[0-9]{2}").allMatches(hours).length != 2) {
-    //If the hours are a special string (not a time)
-    /*If there are new strings that get returned instead of a time,
-      put the strings here. This is a weird way to do it, but
-      we're not in control of the API, so we have to manually determine
-      if this means the establishment is open or not. The 'Closed' case is
-      of my doing however as that simply denotes the establishment is closed.*/
-    switch (hours) {
-      case 'Closed':
-        color = Colors.red;
-        break;
-      case 'Open 24/7':
-        color = Colors.green;
-        break;
-      default:
-        return Container();
-    }
-  } else {
-    var times = hours.split('-');
-    var start = int.parse(times[0]);
-    var end = int.parse(times[1]);
-    var timeNow;
-    if (end < start) end += 2300; // If time goes into next day, prevent wrap
-    if (DateTime.now().minute.toString().length == 1)
-      timeNow = int.parse('${DateTime.now().hour}0${DateTime.now().minute}');
-    else
-      timeNow = int.parse('${DateTime.now().hour}${DateTime.now().minute}');
-    if (timeNow >= start && timeNow < end)
-      color = Colors.green;
-    else
-      color = Colors.red;
+  // For tracking the current day
+  if (day == DateTime.now().weekday) {
+    _currDay = day;
+    _currHours = hoursText;
   }
-  return Container(
-    width: 8,
-    height: 8,
-    decoration: BoxDecoration(shape: BoxShape.circle, color: color),
-  );
+
+  return {'day': theDay, 'hours': hoursText};
 }

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -10,6 +10,7 @@ import '../../core/models/availability.dart';
 import '../../core/providers/availability.dart';
 import 'dining_busyness_bar.dart';
 
+late final int _currDay;
 class DiningDetailView extends StatefulWidget {
   const DiningDetailView({Key? key, required this.data}) : super(key: key);
   final prefix0.DiningModel data;
@@ -165,19 +166,19 @@ class _DiningDetailViewState extends State<DiningDetailView> {
         style: Theme.of(context).textTheme.titleMedium,
       ),
       SizedBox(height: 8),
-      HoursOfDay(model: model, weekday: 1),
+      HoursOfDay(day: 1, model: model),
       buildDivider(context),
-      HoursOfDay(model: model, weekday: 2),
+      HoursOfDay(day: 2, model: model),
       buildDivider(context),
-      HoursOfDay(model: model, weekday: 3),
+      HoursOfDay(day: 3, model: model),
       buildDivider(context),
-      HoursOfDay(model: model, weekday: 4),
+      HoursOfDay(day: 4, model: model),
       buildDivider(context),
-      HoursOfDay(model: model, weekday: 5),
+      HoursOfDay(day: 5, model: model),
       buildDivider(context),
-      HoursOfDay(model: model, weekday: 6),
+      HoursOfDay(day: 6, model: model),
       buildDivider(context),
-      HoursOfDay(model: model, weekday: 7),
+      HoursOfDay(day: 7, model: model),
       SizedBox(height: 16),
     ]);
   }
@@ -382,84 +383,31 @@ Widget buildMenuButton(BuildContext context, prefix0.DiningModel model) {
   }
 }
 
-Widget buildMenu(BuildContext context, prefix0.DiningModel model) {
-  if (model.meals != null) {
-    return DiningMenuList(
-      model: model,
-    );
-  } else {
-    return Container();
-  }
-}
+// TODO: Unused, remove if not needed
+// Widget buildMenu(BuildContext context, prefix0.DiningModel model) {
+//   if (model.meals != null) {
+//     return DiningMenuList(
+//       model: model,
+//     );
+//   } else {
+//     return Container();
+//   }
+// }
 
-// Feeds the "Hours" section of the Dining Detail View.
+// Feeds the "Hours" section of the Dining Detail View //
 class HoursOfDay extends StatelessWidget {
-  final int? weekday;
-  final prefix0.DiningModel? model;
-
-  const HoursOfDay({Key? key, this.weekday, this.model}) : super(key: key);
+  const HoursOfDay({Key? key, required this.day, required this.model}) : super(key: key);
+  final int day;
+  final prefix0.DiningModel model;
 
   @override
   Widget build(BuildContext context) {
-    var theDay;
-    String? theHours;
-    switch (weekday) {
-      case 1:
-        theDay = 'Monday';
-        theHours = model!.regularHours.mon == null
-            ? 'Closed'
-            : model!.regularHours.mon;
-        break;
-      case 2:
-        theDay = 'Tuesday';
-        theHours = model!.regularHours.tue == null
-            ? 'Closed'
-            : model!.regularHours.tue;
-        break;
-      case 3:
-        theDay = 'Wednesday';
-        theHours = model!.regularHours.wed == null
-            ? 'Closed'
-            : model!.regularHours.wed;
-        break;
-      case 4:
-        theDay = 'Thursday';
-        theHours = model!.regularHours.thu == null
-            ? 'Closed'
-            : model!.regularHours.thu;
-        break;
-      case 5:
-        theDay = 'Friday';
-        theHours = model!.regularHours.fri == null
-            ? 'Closed'
-            : model!.regularHours.fri;
-        break;
-      case 6:
-        theDay = 'Saturday';
-        theHours = model!.regularHours.sat == null
-            ? 'Closed'
-            : model!.regularHours.sat;
-        break;
-      case 7:
-        theDay = 'Sunday';
-        theHours = model!.regularHours.sun == null
-            ? 'Closed'
-            : model!.regularHours.sun;
-        break;
-    }
-
-    /*As of 05/05/2020, API may return 'Closed-Closed' as a value. If it does,
-    correct it to look right.*/
-    if (theHours == 'Closed-Closed') theHours = 'Closed';
-
-    // Determine the hours' text
-    final String hoursText =
-        (theHours != null && theHours.contains('Closed')) ||
-                theHours == 'Open 24/7'
-            ? theHours!
-            : (formattedTimeRange(theHours) ?? theHours!);
+    // Extract the hours for the given day from the model
+    var result = extractDayHours(day, model);
+    var theDay = result['day'];
+    var hoursText = result['hours'];
     // Determine the hours' text style
-    final TextStyle hoursTextStyle = weekday == DateTime.now().weekday
+    final TextStyle hoursTextStyle = day == DateTime.now().weekday
         ? TextStyle(
             fontSize: 17.0,
             fontWeight: FontWeight.w700,
@@ -467,8 +415,9 @@ class HoursOfDay extends StatelessWidget {
                 ? lightPrimaryColor
                 : darkPrimaryColor2)
         : Theme.of(context).textTheme.bodySmall!;
-
-    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+    // Display the given day and hours in a row, if the given day is today, add a green dot
+    return Column(crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
       Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
@@ -476,14 +425,10 @@ class HoursOfDay extends StatelessWidget {
             flex: 3,
             child: Row(
               children: [
-                weekday == DateTime.now().weekday
-                    ? buildGreenDot(theHours!)
-                    : Container(width: 10),
-                SizedBox(width: 5),
                 // "Monday" - Bold if today is Monday.
                 Text(
-                  '$theDay ',
-                  style: weekday == DateTime.now().weekday
+                  '$theDay',
+                  style: day == DateTime.now().weekday
                       ? TextStyle(
                           fontSize: 17.0,
                           fontWeight: FontWeight.w700,
@@ -503,7 +448,7 @@ class HoursOfDay extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
                 Text(
-                  hoursText,
+                  hoursText!,
                   style: hoursTextStyle,
                 ),
               ],
@@ -513,45 +458,107 @@ class HoursOfDay extends StatelessWidget {
       ),
     ]);
   }
+}
 
-  Widget buildGreenDot(String hours) {
-    MaterialColor color;
-    if (RegExp(r"\b[0-9]{2}").allMatches(hours).length != 2) {
-      //If the hours are a special string (not a time)
-      /*If there are new strings that get returned instead of a time,
+Map<String, String> extractDayHours(int day, prefix0.DiningModel? model) {
+  var theDay;
+  var theHours;
+  // Extract the hours of the given day
+  switch (day) {
+    case 1:
+      theDay = 'Monday';
+      theHours = model!.regularHours.mon == null
+          ? 'Closed'
+          : model.regularHours.mon;
+      break;
+    case 2:
+      theDay = 'Tuesday';
+      theHours = model!.regularHours.tue == null
+          ? 'Closed'
+          : model.regularHours.tue;
+      break;
+    case 3:
+      theDay = 'Wednesday';
+      theHours = model!.regularHours.wed == null
+          ? 'Closed'
+          : model.regularHours.wed;
+      break;
+    case 4:
+      theDay = 'Thursday';
+      theHours = model!.regularHours.thu == null
+          ? 'Closed'
+          : model.regularHours.thu;
+      break;
+    case 5:
+      theDay = 'Friday';
+      theHours = model!.regularHours.fri == null
+          ? 'Closed'
+          : model.regularHours.fri;
+      break;
+    case 6:
+      theDay = 'Saturday';
+      theHours = model!.regularHours.sat == null
+          ? 'Closed'
+          : model.regularHours.sat;
+      break;
+    case 7:
+      theDay = 'Sunday';
+      theHours = model!.regularHours.sun == null
+          ? 'Closed'
+          : model.regularHours.sun;
+      break;
+  }
+
+  /*As of 05/05/2020, API may return 'Closed-Closed' as a value. If it does,
+    correct it to look right.*/
+  if (theHours == 'Closed-Closed') theHours = 'Closed';
+  // Determine the hours' text
+  final String hoursText =
+  (theHours != null && theHours.contains('Closed')) ||
+      theHours == 'Open 24/7'
+      ? theHours!
+      : (formattedTimeRange(theHours) ?? theHours!);
+
+  return {'day': theDay, 'hours': hoursText};
+}
+
+Widget buildGreenDot(String hours) {
+  MaterialColor color;
+  if (RegExp(r"\b[0-9]{2}").allMatches(hours).length != 2) {
+    //If the hours are a special string (not a time)
+    /*If there are new strings that get returned instead of a time,
       put the strings here. This is a weird way to do it, but
       we're not in control of the API, so we have to manually determine
       if this means the establishment is open or not. The 'Closed' case is
       of my doing however as that simply denotes the establishment is closed.*/
-      switch (hours) {
-        case 'Closed':
-          color = Colors.red;
-          break;
-        case 'Open 24/7':
-          color = Colors.green;
-          break;
-        default:
-          return Container();
-      }
-    } else {
-      var times = hours.split('-');
-      var start = int.parse(times[0]);
-      var end = int.parse(times[1]);
-      var timeNow;
-      if (end < start) end += 2300; // If time goes into next day, prevent wrap
-      if (DateTime.now().minute.toString().length == 1)
-        timeNow = int.parse('${DateTime.now().hour}0${DateTime.now().minute}');
-      else
-        timeNow = int.parse('${DateTime.now().hour}${DateTime.now().minute}');
-      if (timeNow >= start && timeNow < end)
-        color = Colors.green;
-      else
+    switch (hours) {
+      case 'Closed':
         color = Colors.red;
+        break;
+      case 'Open 24/7':
+        color = Colors.green;
+        break;
+      default:
+        return Container();
     }
-    return Container(
-      width: 8,
-      height: 8,
-      decoration: BoxDecoration(shape: BoxShape.circle, color: color),
-    );
+  } else {
+    var times = hours.split('-');
+    var start = int.parse(times[0]);
+    var end = int.parse(times[1]);
+    var timeNow;
+    if (end < start) end += 2300; // If time goes into next day, prevent wrap
+    if (DateTime.now().minute.toString().length == 1)
+      timeNow = int.parse('${DateTime.now().hour}0${DateTime.now().minute}');
+    else
+      timeNow = int.parse('${DateTime.now().hour}${DateTime.now().minute}');
+    if (timeNow >= start && timeNow < end)
+      color = Colors.green;
+    else
+      color = Colors.red;
   }
+  return Container(
+    width: 8,
+    height: 8,
+    decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+  );
 }

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -28,16 +28,13 @@ class _DiningDetailViewState extends State<DiningDetailView> {
 
   @override
   Widget build(BuildContext context) {
+    final detailWidgets = buildDetailView(context, widget.data);
     return ContainerView(
       child: ListView.separated(
-        itemCount: buildDetailView(context, widget.data).length,
-        separatorBuilder: (context, index) {
-          return SizedBox(height: 8);
-        },
-        padding: const EdgeInsets.all(16),
-        itemBuilder: (context, index) {
-          return buildDetailView(context, widget.data)[index];
-        },
+          itemCount: detailWidgets.length,
+          separatorBuilder: (context, index) => SizedBox(height: 8),
+          padding: const EdgeInsets.all(16),
+          itemBuilder: (context, index) => detailWidgets[index],
       ),
     );
   }

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -256,7 +256,7 @@ String? findNextOpenTime(dining_model.RegularHours hours) {
     int nextDay = (now.weekday + i - 1) % 7;
     String? range = days[nextDay];
     if (range != null && range != 'Closed-Closed') {
-      return formattedTimeRange(range)?.split('–').first;
+      return formattedTimeRange(range)?.split('-').first.trim();
     }
   }
   return null;

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -63,9 +63,13 @@ class DiningList extends StatelessWidget {
           );
   }
 
-  Widget textClosed(BuildContext context) {
-    return Text('Closed', style: Theme.of(context).textTheme.bodySmall);
+Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTime}) {
+  String closedText = 'Closed';
+  if (nextOpenDay != null && nextOpenTime != null) {
+    closedText += '. Opens $nextOpenDay at $nextOpenTime.';
   }
+  return Text(closedText, style: Theme.of(context).textTheme.bodySmall);
+}
 
   Widget getHoursForToday(dining_model.RegularHours hours, BuildContext context) {
     int weekday = DateTime.now().weekday;
@@ -76,50 +80,50 @@ class DiningList extends StatelessWidget {
         if (hours.mon != null)
           dayHours = hours.mon;
         else
-          return textClosed(context);
+          return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
         break;
       case 2:
         if (hours.tue != null)
           dayHours = hours.tue;
         else
-          return textClosed(context);
+          return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
         break;
       case 3:
         if (hours.wed != null)
           dayHours = hours.wed;
         else
-          return textClosed(context);
+          return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
         break;
       case 4:
         if (hours.thu != null)
           dayHours = hours.thu;
         else
-          return textClosed(context);
+          return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
         break;
       case 5:
         if (hours.fri != null)
           dayHours = hours.fri;
         else
-          return textClosed(context);
+          return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
         break;
       case 6:
         if (hours.sat != null)
           dayHours = hours.sat;
         else
-          return textClosed(context);
+          return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
         break;
       case 7:
         if (hours.sun != null)
           dayHours = hours.sun;
         else
-          return textClosed(context);
+          return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
         break;
       default:
-        return textClosed(context);
+        return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
     }
     if (RegExp(r"\b[0-9]{2}").allMatches(dayHours!).length != 2) {
       if (dayHours == 'Closed-Closed')
-        return textClosed(context);
+        return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
       else {
         print('test');
         return Text(dayHours);
@@ -221,4 +225,39 @@ class DiningList extends StatelessWidget {
       ),
     );
   }
+}
+
+String? findNextOpenDay(dining_model.RegularHours hours) {
+  final days = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+  final now = DateTime.now();
+  for (int i = 1; i <= 7; i++) {
+    int nextDay = (now.weekday + i - 1) % 7;
+    String? value;
+    switch (nextDay + 1) {
+      case 1: value = hours.mon; break;
+      case 2: value = hours.tue; break;
+      case 3: value = hours.wed; break;
+      case 4: value = hours.thu; break;
+      case 5: value = hours.fri; break;
+      case 6: value = hours.sat; break;
+      case 7: value = hours.sun; break;
+    }
+    if (value != null && value != 'Closed-Closed') {
+      return days[nextDay][0].toUpperCase() + days[nextDay].substring(1);
+    }
+  }
+  return null;
+}
+
+String? findNextOpenTime(dining_model.RegularHours hours) {
+  final days = [hours.mon, hours.tue, hours.wed, hours.thu, hours.fri, hours.sat, hours.sun];
+  final now = DateTime.now();
+  for (int i = 1; i <= 7; i++) {
+    int nextDay = (now.weekday + i - 1) % 7;
+    String? range = days[nextDay];
+    if (range != null && range != 'Closed-Closed') {
+      return formattedTimeRange(range)?.split('–').first;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
Cleaned up codebase for dining by applying the Separations of Concerns principle. This is so that the are not a lot of things going on inside the same widget and so future developers can tweak values more easily.

I also added the "Closed" text to reflect the Figma design:  
![Screenshot_20250619-113755](https://github.com/user-attachments/assets/11c3103c-2334-4b3d-8915-21d2a7aba35e)  

And I fixed the margin of the green dot to almost reflect the figma design:  
![image](https://github.com/user-attachments/assets/687757ee-c6e7-416f-b4cb-8ddb8843de17)

Figma:  
![image](https://github.com/user-attachments/assets/7c36ed08-a1ef-463c-b2ea-752ec7681c4d)

The reason why I couldn't place the green dot "Outside" the Column object that was holding the Hours section is because the Column holding the Hours section is the only object holding the contents inside the hours section.  Meaning, there's no "outside".    
![image](https://github.com/user-attachments/assets/70f70353-9964-4e23-8011-053b938cde8c)


So the only way to place the green dot "outside" the column (in that small white space) with our current implementation was to use a stack instead of a column, and a Positioned widget that overlays the green dot at the left of the current day's row (based on its index/position in the list). Or I could also have shifted ALL the elements in the dining detail view screen more to the right, but that didn't look good and it would not reflect the Figma design anymore.

The changes in this PR are still necessary just in case we find a safe solution to place the green dot anywhere at will OR we want to go back to having a small space where the green dot is if no green dot is rendered.  

I also fixed some bugs (see commit history).

## Changelog
[General] [Fix] - Re-factored Dining code.


## Test Plan
Ensure no overflow, no weird behavior, no inconsistencies across different screens.

