### PR TITLE
Fixed overflow and adjusted spacing to reflect the figma design - CAAPP-381

### DIFF
--- a/lib/ui/common/card_container.dart
+++ b/lib/ui/common/card_container.dart
@@ -141,7 +141,7 @@ class CardContainer extends StatelessWidget {
       // web cards are still sized with static values
       return Container(
         width: double.infinity,
-        constraints: BoxConstraints(minHeight: cardMinHeight, maxHeight: 340),
+        constraints: BoxConstraints(minHeight: cardMinHeight, maxHeight: 375),
         child: child(),
       );
     } else if (titleText == "PARKING") {

--- a/lib/ui/shuttle/shuttle_card.dart
+++ b/lib/ui/shuttle/shuttle_card.dart
@@ -100,7 +100,6 @@ class _ShuttleCardState extends State<ShuttleCard> {
               },
             ),
           ),
-          SizedBox(height: 8),
           DotsIndicator(
             position: _currentPage.toDouble(),
             dotsCount: renderList.length,

--- a/lib/ui/shuttle/shuttle_card.dart
+++ b/lib/ui/shuttle/shuttle_card.dart
@@ -61,8 +61,7 @@ class _ShuttleCardState extends State<ShuttleCard> {
     );
   }
 
-  Widget buildShuttleCard(List<ShuttleStopModel> stopsToRender,
-      Map<int, List<ArrivingShuttle>> arrivalsToRender) {
+  Widget buildShuttleCard(List<ShuttleStopModel> stopsToRender, Map<int, List<ArrivingShuttle>> arrivalsToRender) {
     List<Widget> renderList = [];
     try {
       // Initialize first shuttle display with arrival information
@@ -81,6 +80,7 @@ class _ShuttleCardState extends State<ShuttleCard> {
       //           arrivalsToRender[_shuttleCardDataProvider.closestStop!.id]));
       // }
 
+      // Display all the shuttle stops with their respective arrivals
       for (var i = 0; i < _shuttleCardDataProvider.stopsToRender.length; i++) {
         renderList.add(ShuttleDisplay(
             stop: _shuttleCardDataProvider.stopsToRender[i],
@@ -100,6 +100,7 @@ class _ShuttleCardState extends State<ShuttleCard> {
               },
             ),
           ),
+          SizedBox(height: 8),
           DotsIndicator(
             position: _currentPage.toDouble(),
             dotsCount: renderList.length,
@@ -118,9 +119,7 @@ class _ShuttleCardState extends State<ShuttleCard> {
       return Container(
         width: double.infinity,
         child: Center(
-          child: Container(
-            child: Text('An error occurred, please try again.' + e.toString()),
-          ),
+          child: Text('An error occurred, please try again. ${e.toString()}'),
         ),
       );
     }

--- a/lib/ui/shuttle/shuttle_display.dart
+++ b/lib/ui/shuttle/shuttle_display.dart
@@ -38,7 +38,8 @@ class ShuttleDisplay extends StatelessWidget {
           SizedBox(height: 16),
           buildNextArrivalsText(context),
           SizedBox(height: 16),
-          buildNextArrivalsList(context)
+          buildNextArrivalsList(context),
+          SizedBox(height: 8),
         ],
       );
     }
@@ -196,7 +197,7 @@ class ShuttleDisplay extends StatelessWidget {
 
   Widget buildNextArrivalsList(BuildContext context) {
     List<Widget> arrivalsToRender = [];
-    int count = arrivingShuttles!.length - 1 < 2 ? arrivingShuttles!.length - 1 : 2;
+    int count = (arrivingShuttles!.length - 1).clamp(0, 2);
     for (var index = 1; index <= count; index++) {
       arrivalsToRender.add(buildArrivalTime(context, arrivingShuttles![index]));
       if (index != count) {

--- a/lib/ui/shuttle/shuttle_display.dart
+++ b/lib/ui/shuttle/shuttle_display.dart
@@ -39,7 +39,6 @@ class ShuttleDisplay extends StatelessWidget {
           buildNextArrivalsText(context),
           SizedBox(height: 16),
           buildNextArrivalsList(context),
-          SizedBox(height: 8),
         ],
       );
     }

--- a/lib/ui/shuttle/shuttle_display.dart
+++ b/lib/ui/shuttle/shuttle_display.dart
@@ -130,13 +130,18 @@ class ShuttleDisplay extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
               SizedBox(width: 16),
-              Text(arrivingShuttles![0].routeName,
-                style: TextStyle(
-                  fontSize: 23.0,
-                  fontWeight: FontWeight.w400,
-                  color: Theme.of(context).brightness == Brightness.light
-                      ? descriptiveTextColorLight
-                      : descriptiveTextColorDark,
+              Flexible(
+                child: Text(
+                  arrivingShuttles![0].routeName,
+                  style: TextStyle(
+                    fontSize: 23.0,
+                    fontWeight: FontWeight.w400,
+                    color: Theme.of(context).brightness == Brightness.light
+                        ? descriptiveTextColorLight
+                        : descriptiveTextColorDark,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
                 ),
               ),
             ],
@@ -223,12 +228,18 @@ class ShuttleDisplay extends StatelessWidget {
             ),
           ),
         ),
-        Text(
-          shuttle.routeName,
-          style: TextStyle(fontSize: 16),
+        Expanded(
+          flex: 3,
+          child: Text(
+            shuttle.routeName,
+            style: TextStyle(fontSize: 16),
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+          ),
         ),
         Expanded(
-          child: Container(),
+            flex: 1,
+            child: Container()
         ),
         Padding(
           padding: const EdgeInsets.all(8.0),


### PR DESCRIPTION
## Summary
Fixed the bottom overflow of the arrivals list and limited the amount of arrivals by 2.
![share_4155542199646704593](https://github.com/user-attachments/assets/9231a429-af07-4d8e-8d5c-db0aeadaaf04)

Cases I thought about to ensure the shuttle card will never render more than 2 arrivals:  
If `arrivingShuttles.length = 0:`
count = `(0 - 1).clamp(0, 2)` = `(-1).clamp(0, 2)` = 0
The loop does not run.


If `arrivingShuttles.length = 1:`
count = `(1 - 1).clamp(0, 2)` = 0
The loop does not run.


If `arrivingShuttles.length = 2:`
count = `(2 - 1).clamp(0, 2)` = 1
The loop runs for index = 1 (one time).


If `arrivingShuttles.length = 3:`
count = `(3 - 1).clamp(0, 2)` = 2
The loop runs for index = 1, 2 (two times).


If `arrivingShuttles.length = 4:`
count = `(4 - 1).clamp(0, 2)` = `3.clamp(0, 2)` = 2
The loop runs for index = 1, 2 (two times).


## Changelog
[General] [Fix] - Fixed bottom overflow of the shuttle card.


## Test Plan
Ensure no more overflow.

