### PR TITLE
(CAAPP-380) Generalized vendor logo names

### DIFF
--- a/lib/core/models/dining.dart
+++ b/lib/core/models/dining.dart
@@ -74,6 +74,7 @@ class DiningModel
         specialHours = (json["specialHours"] == null || json["specialHours"].isEmpty)
             ? null
             : SpecialHour.fromJson(json["specialHours"]),
+        vendorLogo = json["vendorLogo"],
         url = json["url"],
         menuWebsite = json["menuWebsite"];
 
@@ -94,6 +95,7 @@ class DiningModel
         "regularHours": regularHours.toJson(),
         "specialHours": specialHours?.toJson(),
         "url": url,
+        "vendorLogo": vendorLogo,
         "menuWebsite": menuWebsite,
         "distance": distance,
       };
@@ -107,7 +109,6 @@ class Image
   String? large;
   // TODO: no caption is valid JSON response. Should this be empty str rather than null?
   String? caption;
-
 
   Image({
     this.small,

--- a/lib/core/providers/dining.dart
+++ b/lib/core/providers/dining.dart
@@ -23,52 +23,8 @@ class DiningDataProvider extends ChangeNotifier {
   /// SERVICES
   var _diningService = DiningService();
 
-  /// LOGOS
+  /// VENDOR LOGOS
   final diningLogosEndpoint = "https://cdn.ucsd.edu/dining-logos/";
-  final diningLogos = [ // Add more logos as needed (Format: "name-of-vendor.png")
-    "art-of-espresso.png",
-    "audreys.png",
-    "blue-bowl.png",
-    "blue-wave-bistro.png",
-    "canyon-vista-marketplace.png",
-    "carlolines.png",
-    "club-med.png",
-    "crafted.png",
-    "destiny-coast.png",
-    "fan-fan.png",
-    "faculty-club.png",
-    "foodworx.png",
-    "gong-cha.png",
-    "james-place.png",
-    "johns.png",
-    "ocean-view.png",
-    "pacific-cafe.png",
-    "pines.png",
-    "plant-power.png",
-    "restaurants-at-sixth.png",
-    "rogers-market.png",
-    "roots.png",
-    "sixth-market.png",
-    "sixty-four-degrees.png",
-    "street-corner.png",
-    "sunshine-market.png",
-    "tahini.png",
-    "the-bistro.png",
-    "ventanas.png",
-    "verdeli.png",
-  ];
-
-  void fetchDiningMenu(String menuId) async {
-    _isLoading = true; _error = null;
-    notifyListeners();
-    if (await _diningService.fetchMenu(menuId)) {
-      _diningMenuItemModels[menuId] = _diningService.menuData!;
-    } else {
-      _error = _diningService.error;
-    }
-    _isLoading = false;
-    notifyListeners();
-  }
 
   void fetchDiningLocations() async {
     _isLoading = true; _error = null;
@@ -88,26 +44,19 @@ class DiningDataProvider extends ChangeNotifier {
           }
         }
 
-        ///////////// Map vendor with its logo /////////////
-        for (var i = 0; i < diningLogos.length; i++) {
-          // Normalize model name and logo names to check...
-          final modelName = normalize(model.name);
-          final logoName = normalize(diningLogos[i].split('.')[0]);
-          // ...if logo name is a substring of the model name
-          if (modelName.contains(logoName)) {
-            model.vendorLogo = diningLogosEndpoint + diningLogos[i];
-            // print('Found logo for ${model.name}: ${model.vendorLogo}');
-            break;
-          }
+        ///////////// Map the vendor with its logo /////////////
+        // Normalize model name (no apostrophes, all lowercase, spaces replaced with hyphens)
+        final vendorName = normalizeModelName(model.name);
+        // Build the endpoint for the vendor logo for this model name
+        final vendorLogoEndpoint = diningLogosEndpoint + vendorName + ".png";
+        // Check if the logo exists
+        if (await _diningService.fetchVendorLogo(vendorLogoEndpoint)) {
+          // Feed the vendor logo into the model
+          model.vendorLogo = vendorLogoEndpoint;
+          // print('Found logo for ${model.name}: ${model.vendorLogo}');
+        } else {
+          model.vendorLogo = null; // not found
         }
-
-        // Special Cases
-        if(model.name == '64 Degrees')
-          model.vendorLogo = diningLogosEndpoint + "sixty-four-degrees.png";
-        if(model.name == 'Pacific Café & Catering')
-          model.vendorLogo = diningLogosEndpoint + "pacific-cafe.png";
-        if(model.name == 'Caroline\'s Seaside Cafe')
-          model.vendorLogo = diningLogosEndpoint + "carlolines.png";
 
         // Save the data
         mapOfDiningLocations[model.name] = model;
@@ -121,6 +70,28 @@ class DiningDataProvider extends ChangeNotifier {
       _lastUpdated = DateTime.now();
     } else {
       /// TODO: determine what error to show to the user
+      _error = _diningService.error;
+    }
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  /// Removes apostrophes and non-alphanumeric characters
+  String normalizeModelName(String input) {
+    return input
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r"['’]"), '')            // remove apostrophes
+        .replaceAll(RegExp(r"\s+"), '-')            // replace spaces with hyphens
+        .replaceAll(RegExp(r"[^a-z0-9\-]"), '');    // remove all non-alphanumeric except hyphens
+  }
+
+  void fetchDiningMenu(String menuId) async {
+    _isLoading = true; _error = null;
+    notifyListeners();
+    if (await _diningService.fetchMenu(menuId)) {
+      _diningMenuItemModels[menuId] = _diningService.menuData!;
+    } else {
       _error = _diningService.error;
     }
     _isLoading = false;
@@ -201,14 +172,6 @@ class DiningDataProvider extends ChangeNotifier {
     /// check if we have a coordinates object
     if (_coordinates != null) return reorderLocations();
     return _diningModels.values.toList();
-  }
-
-  /// Removes apostrophes and non-alphanumeric characters
-  String normalize(String input) {
-    return input
-        .toLowerCase()
-        .replaceAll(RegExp(r"['’]"), '')       // remove apostrophes
-        .replaceAll(RegExp(r"[^a-z0-9]"), ''); // remove all non-alphanumeric
   }
 
   /// SIMPLE SETTERS

--- a/lib/core/providers/dining.dart
+++ b/lib/core/providers/dining.dart
@@ -34,7 +34,6 @@ class DiningDataProvider extends ChangeNotifier {
     /// fetch dining locations from the service
     if (await _diningService.fetchData()) {
       for (DiningModel model in _diningService.data) {
-
         // This fixes the image URLs to avoid 404 errors
         // TODO: Remove this if we are not using model.images anymore due to having VendorLogos now
         if (model.images != null) {
@@ -44,20 +43,8 @@ class DiningDataProvider extends ChangeNotifier {
           }
         }
 
-        ///////////// Map the vendor with its logo /////////////
-        // Normalize model name (no apostrophes, all lowercase, spaces replaced with hyphens)
-        final vendorName = normalizeModelName(model.name);
-        // Build the endpoint for the vendor logo for this model name
-        final vendorLogoEndpoint = diningLogosEndpoint + vendorName + ".png";
-        // Check if the logo exists
-        if (await _diningService.fetchVendorLogo(vendorLogoEndpoint)) {
-          // Feed the vendor logo into the model
-          model.vendorLogo = vendorLogoEndpoint;
-          // print('Found logo for ${model.name}: ${model.vendorLogo}');
-        } else {
-          model.vendorLogo = null; // not found
-        }
-
+        print("==============================");
+        print("Dining Location: ${model.name} and vendor logo: ${model.vendorLogo}");
         // Save the data
         mapOfDiningLocations[model.name] = model;
       }
@@ -74,16 +61,6 @@ class DiningDataProvider extends ChangeNotifier {
     }
     _isLoading = false;
     notifyListeners();
-  }
-
-  /// Removes apostrophes and non-alphanumeric characters
-  String normalizeModelName(String input) {
-    return input
-        .trim()
-        .toLowerCase()
-        .replaceAll(RegExp(r"['’]"), '')            // remove apostrophes
-        .replaceAll(RegExp(r"\s+"), '-')            // replace spaces with hyphens
-        .replaceAll(RegExp(r"[^a-z0-9\-]"), '');    // remove all non-alphanumeric except hyphens
   }
 
   void fetchDiningMenu(String menuId) async {

--- a/lib/core/services/dining.dart
+++ b/lib/core/services/dining.dart
@@ -67,6 +67,27 @@ class DiningService {
     }
   }
 
+  /// Used to check whether a vendor logo exists in the CDN endpoint.
+  Future<bool> fetchVendorLogo(String vendorLogoEndpoint) async {
+    _error = null; _isLoading = true;
+    try {
+      /// fetch data
+      String _response = await NetworkHelper.fetchData(vendorLogoEndpoint);
+
+      /// if the response is empty, it means the logo was not found
+      if (_response.isEmpty) {
+        _error = "Vendor logo not found";
+        return false;
+      }
+      return true;
+    } catch (e) {
+      _error = e.toString();
+      return false;
+    } finally {
+      _isLoading = false;
+    }
+  }
+
   /// SIMPLE GETTERS
   get isLoading => _isLoading;
   get error => _error;

--- a/lib/core/services/dining.dart
+++ b/lib/core/services/dining.dart
@@ -67,27 +67,6 @@ class DiningService {
     }
   }
 
-  /// Used to check whether a vendor logo exists in the CDN endpoint.
-  Future<bool> fetchVendorLogo(String vendorLogoEndpoint) async {
-    _error = null; _isLoading = true;
-    try {
-      /// fetch data
-      String _response = await NetworkHelper.fetchData(vendorLogoEndpoint);
-
-      /// if the response is empty, it means the logo was not found
-      if (_response.isEmpty) {
-        _error = "Vendor logo not found";
-        return false;
-      }
-      return true;
-    } catch (e) {
-      _error = e.toString();
-      return false;
-    } finally {
-      _isLoading = false;
-    }
-  }
-
   /// SIMPLE GETTERS
   get isLoading => _isLoading;
   get error => _error;

--- a/lib/ui/dining/dining_card.dart
+++ b/lib/ui/dining/dining_card.dart
@@ -26,9 +26,14 @@ class DiningCard extends StatelessWidget {
           Provider.of<DiningDataProvider>(context).diningModels),
       actionButtons: [
         ActionButton(
-            buttonText: 'VIEW ALL DINING OPTIONS',
-            onPressed: () =>
-                Navigator.pushNamed(context, RoutePaths.DiningViewAll))
+           buttonText: 'VIEW ALL DINING OPTIONS',
+           onPressed: () {
+              // Only navigate if not loading and no error
+              final provider = Provider.of<DiningDataProvider>(context, listen: false);
+              if (!provider.isLoading && provider.error == null) {
+                Navigator.pushNamed(context, RoutePaths.DiningViewAll);
+              }
+            })
       ],
     );
   }


### PR DESCRIPTION
## Summary
Updated the way we fetched the vendor logos so that it is automatic and it removes the need of adding them manually inside the campus app.
  
The naming convention I came up with is the following:    
1) Grab whatever the name of the dining location is in the dining model i.e. "The Bistro"   
2) Replace all spaces with dashes and set everything to lowercase --> "the-bistro"  
Hence, the vendor logo for "The Bistro" is located at "https://cdn.ucsd.edu/dining-logos/the-bistro.png".  

![image](https://github.com/user-attachments/assets/2e50e9fe-222f-4d60-8b67-8a7bb8088269)

![Screenshot_20250708-112740](https://github.com/user-attachments/assets/4bc0430b-8fe9-4296-9508-f7545724d624)

I also added a condition for the `View All Dining Options` to prevent the user from entering a black screen while the data is still being loaded.

## Changelog
[General] [Change] - Created a standard for fetching vendor logo names and fed them into their respective dining model.


## Test Plan
Ensure vendor logos are still visible and no weird behavior/loading issues.

