### PR TITLE
[CAAPP-313] darken divider lines

### DIFF
--- a/lib/app_styles.dart
+++ b/lib/app_styles.dart
@@ -31,8 +31,9 @@ const Color linkTextColorDark = Color(0xFF5496BC);
 
 const Color descriptiveTextColorLight = Color(0xFF6A6B6D);
 const Color descriptiveTextColorDark = Color(0xFFA1A2A4);
-const Color listTileDividerColorLight = Color(0xFF647185);
-const Color listTileDividerColorDark = Color(0xFF647185);
+
+const Color listTileDividerColorLight = Color(0xFF21293A);
+const Color listTileDividerColorDark = Color(0xFFAFC2D8);
 
 const Color systemErrorTextColorLight = Color(0xFFAC1700);
 const Color systemErrorTextColorDark = Color(0xFFAC1700);


### PR DESCRIPTION

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Change] - Darkened divider lines throughout the app
