### PR TITLE
(CAAPP-305 ) Employee ID Image - Mobile App Base64 decoding logic (CAAPP-373) 

### DIFF
--- a/lib/core/models/employee_id.dart
+++ b/lib/core/models/employee_id.dart
@@ -36,7 +36,7 @@ class EmployeeIdModel {
         employeeId: json["Employee ID"] == null ? "" : json["Employee ID"],
         department: json["Department"] == null ? "" : json["Department"],
         barcode: json["Barcode"] == null ? "" : json["Barcode"],
-        photo: json["Photo"] == null ? "" : json["Photo"],
+        photo: json["Photo"], // Keep null as null for proper base64 handling
         classificationType: json["Classification Type"] == null
             ? "Employee"
             : json["Classification Type"],

--- a/lib/ui/common/base64_image_widget.dart
+++ b/lib/ui/common/base64_image_widget.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+
+class Base64ImageWidget extends StatelessWidget {
+  final String? base64String;
+  final String placeholderAssetPath;
+  final BoxFit fit;
+  final double? width;
+  final double? height;
+
+  const Base64ImageWidget({
+    Key? key,
+    required this.base64String,
+    required this.placeholderAssetPath,
+    this.fit = BoxFit.fill,
+    this.width,
+    this.height,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Check if base64String is valid and not empty
+    if (base64String == null || base64String!.isEmpty || base64String!.trim().isEmpty) {
+      return _buildPlaceholder();
+    }
+
+    try {
+      // Clean the base64 string (remove any whitespace)
+      String cleanBase64 = base64String!.trim();
+      
+      // Decode the base64 string
+      Uint8List bytes = base64Decode(cleanBase64);
+      
+      // Return the decoded image
+      return Image.memory(
+        bytes,
+        fit: fit,
+        width: width,
+        height: height,
+        errorBuilder: (context, error, stackTrace) {
+          // If there's an error displaying the base64 image, show placeholder
+          print('Error displaying base64 image: $error');
+          return _buildPlaceholder();
+        },
+      );
+    } catch (e) {
+      // If base64 decoding fails, show placeholder
+      print('Error decoding base64 image: $e');
+      return _buildPlaceholder();
+    }
+  }
+
+  Widget _buildPlaceholder() {
+    return Image.asset(
+      placeholderAssetPath,
+      fit: fit,
+      width: width,
+      height: height,
+    );
+  }
+}

--- a/lib/ui/employee_id/employee_id_card.dart
+++ b/lib/ui/employee_id/employee_id_card.dart
@@ -6,6 +6,7 @@ import 'package:campus_mobile_experimental/core/providers/cards.dart';
 import 'package:campus_mobile_experimental/core/providers/employee_id.dart';
 import 'package:campus_mobile_experimental/core/utils/webview.dart';
 import 'package:campus_mobile_experimental/ui/common/card_container.dart';
+import 'package:campus_mobile_experimental/ui/common/base64_image_widget.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -96,8 +97,9 @@ class _EmployeeIdCardState extends State<EmployeeIdCard> {
               children: <Widget>[
                 Flexible(
                   flex: 4,
-                  child: Image.asset(
-                    'assets/images/staff_id_placeholder.png',
+                  child: Base64ImageWidget(
+                    base64String: employeeIdModel!.photo,
+                    placeholderAssetPath: 'assets/images/staff_id_placeholder.png',
                     fit: BoxFit.fill,
                   ),
                 ),

--- a/test/ui/common/base64_image_widget_test.dart
+++ b/test/ui/common/base64_image_widget_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:campus_mobile_experimental/ui/common/base64_image_widget.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  group('Base64ImageWidget Tests', () {
+    testWidgets('should show placeholder when base64String is null', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Base64ImageWidget(
+              base64String: null,
+              placeholderAssetPath: 'assets/images/staff_id_placeholder.png',
+            ),
+          ),
+        ),
+      );
+
+      // Should find the placeholder image
+      expect(find.byType(Image), findsOneWidget);
+    });
+
+    testWidgets('should show placeholder when base64String is empty', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Base64ImageWidget(
+              base64String: '',
+              placeholderAssetPath: 'assets/images/staff_id_placeholder.png',
+            ),
+          ),
+        ),
+      );
+
+      // Should find the placeholder image
+      expect(find.byType(Image), findsOneWidget);
+    });
+
+    testWidgets('should show placeholder when base64String is invalid', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Base64ImageWidget(
+              base64String: 'invalid_base64_string',
+              placeholderAssetPath: 'assets/images/staff_id_placeholder.png',
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      // Should find the placeholder image
+      expect(find.byType(Image), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implemented base64 image decoding for employee ID photos with placeholder fallback

## Changelog

[General] [Add] - added Base64ImageWidget for decoding employee ID photos with placeholder fallback
[General] [Add] - added unit tests for Base64ImageWidget edge cases
[General] [Change] - updated EmployeeIdCard to use Base64ImageWidget instead of hardcoded placeholder
[General] [Change] - modified EmployeeIdModel to preserve null photo values for proper base64 handling

## Test Plan

Ran simulator for both Android and iPhone on Android Studio

## Image Verification of integration

Image verification of placeholder fallback for non-working Photo URLs returning "null" against CMA base64 logic/UI:

Image verification against CMA base64 logic/UI using public photo URL https://picsum.photos/200/300 :

Image verification against CMA base64 logic/UI using public employee id photo URL

Image verification for WSO2 API response body returning "null" for non-working Photo URLs using new staff-photo API integration:

Image/message verification for WSO2 API response returning base64 encoded string in response for working staff Photo URLs using new staff-photo API integration:

Image showing verification of successful new staff-photo API integration into MyStaffProfile with WSO2 API response returning base64 encoded string for public URLs:

## Notes

Final confirmation will be to test successful rendering of Staff Photo in CMA UI by a Staff personnel