### PR TITLE
(CAAPP-392) Fixed UI for "InvalidDate-InvalidDate" case

### DIFF
--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -392,7 +392,7 @@ class HoursOfDay extends StatelessWidget {
     var result = extractDayHours(day, model);
     var theDay = result['day'];
     var hoursText = (result['hours'] == "Invalid Date-Invalid Date") ? "Unknown Hours" : result['hours'];
-    // Determine the hours' text style    // Determine the hours' text style
+    // Determine the hours' text style
     final TextStyle hoursTextStyle = day == DateTime.now().weekday
         ? TextStyle(
             fontSize: 17.0,

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -391,8 +391,8 @@ class HoursOfDay extends StatelessWidget {
     // Extract the hours for the given day from the model
     var result = extractDayHours(day, model);
     var theDay = result['day'];
-    var hoursText = result['hours'];
-    // Determine the hours' text style
+    var hoursText = (result['hours'] == "Invalid Date-Invalid Date") ? "Unknown Hours" : result['hours'];
+    // Determine the hours' text style    // Determine the hours' text style
     final TextStyle hoursTextStyle = day == DateTime.now().weekday
         ? TextStyle(
             fontSize: 17.0,

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -126,7 +126,7 @@ Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTi
         return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
       if(dayHours == 'Invalid Date-Invalid Date')
         return Text("Unknown hours", style: Theme.of(context).textTheme.bodySmall);
-      print("test");
+      
       return Text(dayHours, style: Theme.of(context).textTheme.bodySmall);
     }
 

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -124,10 +124,10 @@ Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTi
     if (RegExp(r"\b[0-9]{2}").allMatches(dayHours!).length != 2) {
       if (dayHours == 'Closed-Closed')
         return textClosed(context, nextOpenDay: findNextOpenDay(hours), nextOpenTime: findNextOpenTime(hours));
-      else {
-        print('test');
-        return Text(dayHours);
-      }
+      if(dayHours == 'Invalid Date-Invalid Date')
+        return Text("Unknown hours", style: Theme.of(context).textTheme.bodySmall);
+      print("test");
+      return Text(dayHours, style: Theme.of(context).textTheme.bodySmall);
     }
 
     return Text(formattedTimeRange(dayHours) ?? dayHours,


### PR DESCRIPTION
## Summary
Fixed UI for the case where the data inside the result['hours'] is null. This bug should be fixed at the API level (probably because the VPC is not configured properly), and the purpose of this PR is to "gracefully degrade" the UI so it doesn't show "Invalid Date - Invalid Date" to the user.

Before:  
![image](https://github.com/user-attachments/assets/a4519cb2-2fdc-43b5-bc87-2bb15f971ef5)
![image](https://github.com/user-attachments/assets/a2bfeb62-55d4-4307-b400-0b88af36f821)


After:  
![image](https://github.com/user-attachments/assets/4f5169e4-7089-440c-b2f9-21502098fdb6)
![image](https://github.com/user-attachments/assets/d3de73ba-304e-4743-92db-5c07d2052d6f)



## Changelog
[General] [Fix] - Fixed UI for a "graceful degradation" behavior.


## Test Plan
Locations with an invalid date should now say "Unknown hours" with the proper color and text size in both dining list and dining detail views.
