### PR TITLE
Release Feedback CAAPP-401 - Dark mode support for vendor logo CAAPP-399

### DIFF
--- a/lib/app_styles.dart
+++ b/lib/app_styles.dart
@@ -379,3 +379,7 @@ const List<double> grayscaleInvertMatrix = [
   -0.2126, -0.7152, -0.0722, 0, 255, // blue
   0,        0,        0,     1,   0, // alpha
 ];
+
+// Dining logo border and shadow colors for dark mode
+const Color darkLogoBorderColor = Color(0xFF444444); // subtle dark border
+const Color darkLogoShadowColor = Color(0xFF000000); // shadow for logo elevation

--- a/lib/app_styles.dart
+++ b/lib/app_styles.dart
@@ -382,4 +382,4 @@ const List<double> grayscaleInvertMatrix = [
 
 // Dining logo border and shadow colors for dark mode
 const Color darkLogoBorderColor = Color(0xFF444444); // subtle dark border
-const Color darkLogoShadowColor = Color(0xFF000000); // shadow for logo elevation
+const Color darkLogoShadowColor = Colors.white; // use white for shadow in dark mode

--- a/lib/app_styles.dart
+++ b/lib/app_styles.dart
@@ -371,3 +371,11 @@ const darkListTileTheme =
 
 // New Onboarding Screen Colors
 const lightOnboardingScreen = Color.fromARGB(255, 245, 240, 228);
+
+// In app_styles.dart (add this global variable)
+const List<double> grayscaleInvertMatrix = [
+  -0.2126, -0.7152, -0.0722, 0, 255, // red
+  -0.2126, -0.7152, -0.0722, 0, 255, // green
+  -0.2126, -0.7152, -0.0722, 0, 255, // blue
+  0,        0,        0,     1,   0, // alpha
+];

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -60,10 +60,15 @@ class _DiningDetailViewState extends State<DiningDetailView> {
         children: [
           // Vendor Logo
           diningModel.vendorLogo != null
-              ? Image.network(
-                  diningModel.vendorLogo!,
-                  width: 80,
-                  height: 80,
+              ? ColorFiltered(
+                  colorFilter: Theme.of(context).brightness == Brightness.dark
+                      ? const ColorFilter.matrix(grayscaleInvertMatrix)
+                      : const ColorFilter.mode(Colors.transparent, BlendMode.multiply),
+                  child: Image.network(
+                    diningModel.vendorLogo!,
+                    width: 80,
+                    height: 80,
+                  ),
                 )
               : Icon(Icons.restaurant,
                   size: 56,

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -60,10 +60,23 @@ class _DiningDetailViewState extends State<DiningDetailView> {
         children: [
           // Vendor Logo
           diningModel.vendorLogo != null
-              ? ColorFiltered(
-                  colorFilter: Theme.of(context).brightness == Brightness.dark
-                      ? const ColorFilter.matrix(grayscaleInvertMatrix)
-                      : const ColorFilter.mode(Colors.transparent, BlendMode.multiply),
+              ? Container(
+                  decoration: Theme.of(context).brightness == Brightness.dark
+                      ? BoxDecoration(
+                          border: Border.all(
+                            color: darkLogoBorderColor, // global dark border color
+                            width: 2,
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: darkLogoShadowColor.withOpacity(0.5), // global dark shadow color
+                              blurRadius: 8,
+                              offset: Offset(0, 2),
+                            ),
+                          ],
+                          shape: BoxShape.circle,
+                        )
+                      : null,
                   child: Image.network(
                     diningModel.vendorLogo!,
                     width: 80,

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -63,17 +63,11 @@ class _DiningDetailViewState extends State<DiningDetailView> {
               ? Container(
                   decoration: Theme.of(context).brightness == Brightness.dark
                       ? BoxDecoration(
+                          color: lightTextColor,
                           border: Border.all(
-                            color: darkLogoBorderColor, // global dark border color
+                            color: darkLogoBorderColor,
                             width: 2,
                           ),
-                          boxShadow: [
-                            BoxShadow(
-                              color: darkLogoShadowColor.withOpacity(0.5), // global dark shadow color
-                              blurRadius: 8,
-                              offset: Offset(0, 2),
-                            ),
-                          ],
                           shape: BoxShape.circle,
                         )
                       : null,

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -153,9 +153,9 @@ Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTi
             ? Container(
                 decoration: Theme.of(context).brightness == Brightness.dark
                     ? BoxDecoration(
-                        color: Colors.white, // solid white background
+                        color: lightTextColor,
                         border: Border.all(
-                          color: darkLogoBorderColor, // global dark border color
+                          color: darkLogoBorderColor,
                           width: 2,
                         ),
                         shape: BoxShape.circle,

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -150,10 +150,23 @@ Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTi
         width: 48,
         height: 48,
         child: data.vendorLogo != null
-            ? ColorFiltered(
-                colorFilter: Theme.of(context).brightness == Brightness.dark
-                    ? const ColorFilter.matrix(grayscaleInvertMatrix)
-                    : const ColorFilter.mode(Colors.transparent, BlendMode.multiply),
+            ? Container(
+                decoration: Theme.of(context).brightness == Brightness.dark
+                    ? BoxDecoration(
+                        border: Border.all(
+                          color: darkLogoBorderColor, // global dark border color
+                          width: 2,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: darkLogoShadowColor.withOpacity(0.5), // global dark shadow color
+                            blurRadius: 6,
+                            offset: Offset(0, 2),
+                          ),
+                        ],
+                        shape: BoxShape.circle,
+                      )
+                    : null,
                 child: Image.network(
                   data.vendorLogo!,
                   width: 48,

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -153,17 +153,11 @@ Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTi
             ? Container(
                 decoration: Theme.of(context).brightness == Brightness.dark
                     ? BoxDecoration(
+                        color: Colors.white, // solid white background
                         border: Border.all(
                           color: darkLogoBorderColor, // global dark border color
                           width: 2,
                         ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: darkLogoShadowColor.withOpacity(0.5), // global dark shadow color
-                            blurRadius: 6,
-                            offset: Offset(0, 2),
-                          ),
-                        ],
                         shape: BoxShape.circle,
                       )
                     : null,

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -150,10 +150,15 @@ Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTi
         width: 48,
         height: 48,
         child: data.vendorLogo != null
-            ? Image.network(
-                data.vendorLogo!,
-                width: 48,
-                height: 48,
+            ? ColorFiltered(
+                colorFilter: Theme.of(context).brightness == Brightness.dark
+                    ? const ColorFilter.matrix(grayscaleInvertMatrix)
+                    : const ColorFilter.mode(Colors.transparent, BlendMode.multiply),
+                child: Image.network(
+                  data.vendorLogo!,
+                  width: 48,
+                  height: 48,
+                ),
               )
             : Icon(
                 Icons.restaurant,


### PR DESCRIPTION
## Summary
Added dark mode support for Dining vendor logos by adding solid white circular background and gray border in both list and detail views


## Changelog
[General] [Change] - dining_list.dart: updated vendor logo rendering to use a solid white circular background (global color lightTextColor from app_styles.dart) and gray border color (global darkLogoBorderColor from app_styles.dart) in dark mode
[General] [Change] - dining_detail_view.dart: applied the same solid white circular background and border for vendor logos in the detail view for dark mode, as in dining_list.dart


## Test Plan
Ran simulator for both Android and iPhone on Android Studio

<img width="876" height="619" alt="image" src="https://github.com/user-attachments/assets/dc35f5c4-bd53-4955-9826-e6935907954a" />

