### PR TITLE
Use authorized fetch for Events

### DIFF
--- a/lib/core/services/events.dart
+++ b/lib/core/services/events.dart
@@ -4,31 +4,37 @@ import 'package:campus_mobile_experimental/core/models/events.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class EventsService {
-  EventsService() { fetchData(); }
+  EventsService() {
+    fetchData();
+  }
 
   /// STATES
   bool _isLoading = false;
   DateTime? _lastUpdated;
   String? _error;
-    final Map<String, String> headers = {
+  final Map<String, String> headers = {
     "accept": "application/json",
   };
 
   /// MODELS
   late List<EventModel> _data;
 
-
   Future<bool> fetchData() async {
-    _error = null; _isLoading = true;
+    _error = null;
+    _isLoading = true;
     try {
       /// fetch data
-      String _response = await NetworkHelper.fetchData(dotenv.get('EVENTS_ENDPOINT'));
+      String _response = await NetworkHelper.authorizedFetch(
+          dotenv.get('EVENTS_ENDPOINT'), headers);
 
       /// parse data
       final data = eventModelFromJson(_response);
       _data = data;
       return true;
     } catch (e) {
+      if (e.toString().contains("401")) {
+        if (await NetworkHelper.getNewToken(headers)) return await fetchData();
+      }
       _error = e.toString();
       return false;
     } finally {


### PR DESCRIPTION
## Summary
Events API has moved and now requires authentication.

## Changelog
[General][Fix] - use authorized fetch

## Test Plan
Tested with iOS simulator.
Events card now list events.

<img width="385" height="655" alt="image" src="https://github.com/user-attachments/assets/8f067beb-6442-4832-a482-350737448b91" />

