### PR TITLE
[CAAP-407] Single Day Events

### DIFF
--- a/lib/ui/events/event_tile.dart
+++ b/lib/ui/events/event_tile.dart
@@ -55,7 +55,7 @@ class EventTile extends StatelessWidget {
     final df = DateFormat("MMM d y");
     final startDate = df.format(data.startDate.toLocal());
     final endDate = df.format(data.endDate.toLocal());
-    final dateDisplay = data.startDate.day == data.endDate.day
+    final dateDisplay = startDate == endDate
         ? startDate
         : '$startDate - $endDate';
     final startTime = DateFormat.jm().format(data.startDate.toLocal());


### PR DESCRIPTION
## Summary
Single day events are currently showing a date range, when it should only be showing one date.

## Changelog
[General] [Change] - Changed events card ui to display only one date when the event is single day.

## Test Plan
I printed startDate and endDate and found that while they look the same, .day might be different based on timezone and other factors in the DateTime object. Thus, I changed startDate.day == endDate.day to be startDate == endDate.


<img width="326" height="340" alt="Screenshot 2025-07-21 at 3 51 13 PM" src="https://github.com/user-attachments/assets/7e5e1a41-e1cd-428a-bcdd-c1b77eff1e2e" />
