### PR TITLE
[CAAPP-406] - Displaying full day events

### DIFF
--- a/lib/ui/events/event_tile.dart
+++ b/lib/ui/events/event_tile.dart
@@ -53,13 +53,19 @@ class EventTile extends StatelessWidget {
 
   Widget _eventDetailsCard(BuildContext context) {
     final df = DateFormat("MMM d y");
-    final startDate = df.format(data.startDate.toLocal());
-    final endDate = df.format(data.endDate.toLocal());
-    final dateDisplay = startDate == endDate
-        ? startDate
-        : '$startDate - $endDate';
-    final startTime = DateFormat.jm().format(data.startDate.toLocal());
-    final endTime = DateFormat.jm().format(data.endDate.toLocal());
+
+    final localStart = data.startDate.toLocal();
+    final localEnd = data.endDate.toLocal();
+
+    final startDate = df.format(localStart);
+    final endDate = df.format(localEnd);
+    final dateDisplay =
+        startDate == endDate ? startDate : '$startDate - $endDate';
+    final startTime = DateFormat.jm().format(localStart);
+    final endTime = DateFormat.jm().format(localEnd);
+
+    final isAllDay = (localStart.hour == 0) && (localEnd.hour == 23);
+
     final hasTime = startTime != endTime;
     return SizedBox(
       width: tileWidth,
@@ -76,10 +82,12 @@ class EventTile extends StatelessWidget {
             children: [
               _eventImageLoader(data.imageThumb),
               Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+                padding:
+                    const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
                 child: Row(
-                  mainAxisAlignment:
-                      hasTime ? MainAxisAlignment.spaceEvenly : MainAxisAlignment.center,
+                  mainAxisAlignment: hasTime
+                      ? MainAxisAlignment.spaceEvenly
+                      : MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     Flexible(
@@ -94,7 +102,19 @@ class EventTile extends StatelessWidget {
                         child: FittedBox(
                           fit: BoxFit.scaleDown,
                           alignment: Alignment.centerRight,
-                          child: TileTime(time: '$startTime - $endTime'),
+                          child: isAllDay
+                              ? Text('All day',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: Theme.of(context).brightness ==
+                                            Brightness.light
+                                        ? lightPrimaryColor
+                                        : Colors.white,
+                                    fontWeight: FontWeight.w400,
+                                  ))
+                              : TileTime(
+                                  time: '$startTime - $endTime',
+                                ),
                         ),
                       ),
                   ],

--- a/lib/ui/events/events_detail_view.dart
+++ b/lib/ui/events/events_detail_view.dart
@@ -25,6 +25,7 @@ class EventDetailView extends StatelessWidget {
 
   /// TODO: What color to use for dark theme?
   Widget buildDetailView(BuildContext context) {
+
     return ListView(
       children: [
         // Event Image
@@ -73,6 +74,8 @@ class EventDetailView extends StatelessWidget {
               SizedBox(width: 5),
               // Event Time
               Text(
+                data.startDate.toLocal().hour == 0 &&  data.endDate.toLocal().hour == 23 ?
+                    '    All day     ' :
                 DateFormat.jm().format(data.startDate.toLocal()) +
                     ' - ' +
                     DateFormat.jm().format(data.endDate.toLocal()),


### PR DESCRIPTION
## Summary
Full day events were showing 12:AM-11:59PM, when it should be showing "Full day"


## Changelog
[General] [Change] - UI now displays "full day" if the event is from 12.XXAM to 11.XXPM

## Test Plan
I simplified the logic in ui/event_tile.dart to have a variable hold data.startDate.toLocal() and data.endDate.toLocal(). I then checked the hours of these to see if they were 0 and 23 (12AM and 11PM). If so, I changed the code to display "All day".
I also copied the text style themes from the original TileTitle format.  

<img width="354" height="437" alt="Screenshot 2025-07-23 at 12 47 53 PM" src="https://github.com/user-attachments/assets/ad22fb11-701d-4e96-938c-87b247a3e0fb" />
<img width="353" height="630" alt="Screenshot 2025-07-23 at 12 48 12 PM" src="https://github.com/user-attachments/assets/f6a811c6-324f-41a9-887e-49be57795b2b" />
