### PR TITLE
Open Map app on "Get Directions" (Dining detail view)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,6 +6,8 @@
 	<string></string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -16,6 +18,16 @@
 	<string></string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>UC San Diego</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -29,34 +41,31 @@
 			</array>
 		</dict>
 	</array>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>UC San Diego</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>comgooglemaps</string>
+		<string>comgooglemaps-x-callback</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>UC San Diego mobile would like access to the camera. The app needs access to scan QR Codes.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Allowing location access allows cards and map search to display information relevant to your location.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Allowing location access allows cards and map search to display information relevant to your location.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Allowing location access allows cards and map search to display information relevant to your location.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Allowing location access while using the app allows cards and map search to display information relevant to your location.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
@@ -82,9 +91,5 @@
 	<false/>
 	<key>com.transistorsoft.fetch</key>
 	<string></string>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -342,11 +342,24 @@ Widget buildDirectionsButton(BuildContext context, prefix0.DiningModel model) {
           ),
         ],
       ),
-      onPressed: () {
+      onPressed: () async {
+        final lat = model.coordinates!.lat!;
+        final lon = model.coordinates!.lon!;
+        final iosGoogleMapsUrl='comgooglemaps://?daddr=$lat,$lon&directionsmode=walking';
+        final iosAppleMapsUrl='http://maps.apple.com/?daddr=$lat,$lon&dirflg=w';
+        final googleMapsUrl='https://www.google.com/maps/dir/?api=1&destination=$lat,$lon&travelmode=walking';
+
         try {
-          launch(
-              'https://www.google.com/maps/dir/?api=1&destination=${model.coordinates!.lat},${model.coordinates!.lon}&travelmode=walking',
-              forceSafariVC: true);
+          // on iOS, will open in google maps if app is available
+          if (await canLaunch(iosGoogleMapsUrl)) {
+            await launch(iosGoogleMapsUrl, forceSafariVC: false);
+          // on iOS, will open in apple maps if app is available
+          } else if (await canLaunch(iosAppleMapsUrl)) {
+            await launch(iosAppleMapsUrl, forceSafariVC: false);
+          // fallback to google maps link, android will open in google maps app
+          } else {
+            await launch(googleMapsUrl, forceSafariVC: false, forceWebView: false);
+          }
         } catch (e) {
           // an error occurred, do nothing
         }


### PR DESCRIPTION
Open directions on (Google/Apple) map app when available. 

## Summary
<!-- What existing problem does the pull request solve? -->
On Dining Detailed View, when the user presses "Get directions", the app would open an in-app browser page rather then redirecting to the app. This especially affects iOS users. 

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: General
    TYPES:      Fix
    MESSAGE:    Added `LSApplicationQueriesSchemes` in ios/Runner/Info.plist for opening google maps on ios; added more fallback logic if a device fails to open in map app; switched `forceSafariVC` and `forceWebView` to false so default browser can handle routing if one of the map apps are not available

-->
[General] [Fix] - Get Direction button opens map app


## Test Plan
<!--
    iOS: when tapping "Get Direction", opens up google maps app with walking directions; when google maps app is not available (i deleted it), button opens up apple maps with walking directions
    Android: when tapping "Get Direction", opens up google maps with walking directions

https://github.com/user-attachments/assets/4399d094-ae6e-4bfd-ba77-a926521d09c7
https://github.com/user-attachments/assets/52db07e9-8ce2-430a-b183-f39e3c050faf
-->



