### PR TITLE
[CAAP-385] Integrate report it now feature

### DIFF
--- a/lib/ui/profile/profile.dart
+++ b/lib/ui/profile/profile.dart
@@ -8,6 +8,7 @@ import 'package:campus_mobile_experimental/ui/profile/login.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uni_links2/uni_links.dart';
+import '../../core/providers/user.dart';
 import '../../core/utils/webview.dart';
 
 class Profile extends StatelessWidget {
@@ -36,6 +37,10 @@ class Profile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+
+    final _userDataProvider = Provider.of<UserDataProvider>(context);
+    final isLoggedIn = _userDataProvider.isLoggedIn;
+
     initUniLinks(context);
     return Container(
       child: Column(
@@ -111,6 +116,18 @@ class Profile extends StatelessWidget {
                   ),
                   onTap: handlePrivacyTap,
                 ),
+                if(isLoggedIn)
+                  ListTile(
+                    leading: Icon(Icons.warning_amber_rounded,
+                        color: Theme.of(context).iconTheme.color, size: 36.0),
+                    title: Text(
+                      'Report a Campus Facility Issue',
+                      style: Theme.of(context).brightness == Brightness.dark
+                          ? linkTextDark
+                          : linkTextLight,
+                    ),
+                    onTap: handleReportTap,
+                  ),
               ],
             ),
           ),
@@ -132,5 +149,10 @@ class Profile extends StatelessWidget {
   Future<void> handlePrivacyTap() async {
     const privacyUrl = "https://mobile.ucsd.edu/privacy-policy.html";
     openLink(privacyUrl);
+  }
+
+  Future<void>handleReportTap() async {
+    const reportUrl = "https://experience.arcgis.com/experience/91b8f66d6fa547f481c2a1cb6af252d0";
+    openLink(reportUrl);
   }
 }


### PR DESCRIPTION
## Summary
Integrating Report it Now feature in mobile app for signed in users. 

## Changelog
[General] [Add] - Added a tile for report it now in the profile tab, following Figma.


## Test Plan
I first added a List tile similar to the existing ones. Then I added a function for when the user presses the list tile, taking them to the website: https://experience.arcgis.com/experience/91b8f66d6fa547f481c2a1cb6af252d0. Since this feature only appears for logged in users, I also added a check for if the user is logged in using the UserDataProvider. 


<img width="381" height="483" alt="Screenshot 2025-08-05 at 2 17 39 PM" src="https://github.com/user-attachments/assets/5dfe4c1d-90d0-4582-be2b-dd009e2d163e" />
<img width="266" height="373" alt="Screenshot 2025-08-05 at 2 18 23 PM" src="https://github.com/user-attachments/assets/840779a8-fa3e-4688-9417-ebe031d7eb09" />
<img width="269" height="580" alt="Screenshot 2025-08-05 at 2 20 06 PM" src="https://github.com/user-attachments/assets/8ab5d38a-a37a-4919-9577-4e68cbf46361" />
