### PR TITLE
[CAAP-421] fix dark mode logo ui view

### DIFF
--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -64,11 +64,7 @@ class _DiningDetailViewState extends State<DiningDetailView> {
                   decoration: Theme.of(context).brightness == Brightness.dark
                       ? BoxDecoration(
                           color: lightTextColor,
-                          border: Border.all(
-                            color: darkLogoBorderColor,
-                            width: 2,
-                          ),
-                          shape: BoxShape.circle,
+                    borderRadius: BorderRadius.circular(8),
                         )
                       : null,
                   child: Image.network(

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -154,11 +154,7 @@ Widget textClosed(BuildContext context, {String? nextOpenDay, String? nextOpenTi
                 decoration: Theme.of(context).brightness == Brightness.dark
                     ? BoxDecoration(
                         color: lightTextColor,
-                        border: Border.all(
-                          color: darkLogoBorderColor,
-                          width: 2,
-                        ),
-                        shape: BoxShape.circle,
+                  borderRadius: BorderRadius.circular(8),
                       )
                     : null,
                 child: Image.network(


### PR DESCRIPTION
## Summary
The dark mode logo blocks out some of the vendor logos. 


## Changelog
[General] [Fix] - Changed the circle background to be square with rounded borders. 


## Test Plan
I changed the circle shape to the default rectangle shape and added slightly rounded corners. I also deleted the border aspect of the code as it was causing extra padding and extra bordering with a different color (first screenshot shows the bordering, 2nd screenshot is after fix). 


<img width="169" height="165" alt="Screenshot 2025-08-07 at 4 49 16 PM" src="https://github.com/user-attachments/assets/11f62a3f-ccdb-4ddb-b2e6-fdcded27ab89" />
<img width="86" height="109" alt="Screenshot 2025-08-07 at 5 00 06 PM" src="https://github.com/user-attachments/assets/1e60592d-5a24-4ee1-94dc-3359a03f2e43" />
<img width="348" height="421" alt="Screenshot 2025-08-07 at 4 47 17 PM" src="https://github.com/user-attachments/assets/936df2a3-183a-4f37-a556-ce32d023c3c4" />
<img width="329" height="346" alt="Screenshot 2025-08-07 at 4 46 37 PM" src="https://github.com/user-attachments/assets/e31e5286-6ae2-42c9-a3be-1f1fb71df1ff" />