### PR TITLE
[CAAP-402] Change Red/Green Indicator for Dining Card 

### DIFF
--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -399,13 +399,21 @@ class HoursOfDay extends StatelessWidget {
     var theDay = result['day'];
     var hoursText = (result['hours'] == "Invalid Date-Invalid Date") ? "Unknown Hours" : result['hours'];
     // Determine the hours' text style
-    final TextStyle hoursTextStyle = day == DateTime.now().weekday
-        ? TextStyle(
-            fontSize: 17.0,
-            fontWeight: FontWeight.w700,
-            color: Theme.of(context).brightness == Brightness.light
-                ? lightPrimaryColor
-                : darkPrimaryColor2)
+    // final TextStyle hoursTextStyle = day == DateTime.now().weekday
+    //     ? TextStyle(
+    //         fontSize: 17.0,
+    //         fontWeight: FontWeight.w700,
+    //         color: Theme.of(context).brightness == Brightness.light
+    //             ? lightPrimaryColor
+    //             : darkPrimaryColor2)
+    //     : Theme.of(context).textTheme.bodySmall!;
+    final TextStyle hoursTextStyle = day == DateTime.now().weekday ?
+
+    Theme.of(context).textTheme.bodySmall!.copyWith(
+        fontWeight: FontWeight.w700,
+        color: Theme.of(context).brightness == Brightness.light
+            ? lightPrimaryColor
+            : darkPrimaryColor2)
         : Theme.of(context).textTheme.bodySmall!;
 
     // Check if this is the current day
@@ -420,22 +428,32 @@ class HoursOfDay extends StatelessWidget {
               children: [
                 // Show the green dot for today
                 if (isToday) ...[
-                  GreenDot(currHours: hoursText!),
-                  SizedBox(width: 5),
+                  SizedBox(
+                    width: 0,
+                    height: 0,
+                    child: OverflowBox(
+                      maxWidth: 10, //enough width and height to hold the dot
+                      maxHeight: 10,
+                      alignment: Alignment.centerLeft,
+                      child: Transform.translate(
+                        offset: const Offset(-11.5, 0),
+                        child: GreenDot(currHours: hoursText!),
+                      ),
+                    ),
+                  ),
+                  // SizedBox(width: 2),
                 ],
                 // "Monday" - Bold if today is Monday.
                 Text(
                   '$theDay',
                   style: isToday
-                      ? TextStyle(
-                          fontSize: 17.0,
-                          fontWeight: FontWeight.w700,
-                          color:
-                              Theme.of(context).brightness == Brightness.light
-                                  ? lightPrimaryColor
-                                  : darkPrimaryColor2)
+                    ? Theme.of(context).textTheme.bodySmall!.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: Theme.of(context).brightness == Brightness.light
+                                      ? lightPrimaryColor
+                                      : darkPrimaryColor2)
                       : Theme.of(context).textTheme.bodySmall,
-                ),
+                  ),
               ],
             ),
           ),
@@ -517,8 +535,8 @@ class GreenDot extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 8,
-      height: 8,
+      width: 7,
+      height: 7,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         color: _determineColor(),


### PR DESCRIPTION
## Summary
The current UI's red/green indicator pushes the day to the right.

## Changelog
[General] [Change] - Changed the red/green indicator dot to be pushed to the left, and the font of the bolded day/hours to be the same as the others, designed according to Figma.


## Test Plan
I changed the logic which decides the font style so both the bolded and non bolded have the same theme (before it was using different styles). I also used an overflow box so the dot could be outside of the column. Flutter gave me an infinite size layout error so I added a sized box on top of that with size 0, just so the overflow box widget wouldn't have an infinite size. 
<img width="356" height="567" alt="Screenshot 2025-08-11 at 6 46 01 AM" src="https://github.com/user-attachments/assets/63c534d1-2b4c-4371-ab55-804234571278" />
<img width="353" height="569" alt="Screenshot 2025-08-11 at 6 46 22 AM" src="https://github.com/user-attachments/assets/e4e8d382-3007-4a28-a15b-49d7a17769c6" />

