### PR TITLE
Updated point castle,provider,shared preferences,uni links2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ To create a new branch and start working on it:
 git checkout experimental
 
 # Create and checkout a branch named newfeature
-git checkout -b experimental
+git checkout -b newfeature
 ```
 
 You are now ready to begin developing your new feature. Commit your code often, using present-tense and concise verbiage explaining the work completed.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -997,10 +997,10 @@ packages:
     dependency: "direct main"
     description:
       name: pointycastle
-      sha256: d0d95ef66e5327394d2dab33cbcb2cde3a9fb275abe75ebfedd0f54392878df7
+      sha256: "57b6b78df14175658f09c5dfcfc51a46ad9561a3504fe679913dab404d0cc0f2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.7.0"
   pool:
     dependency: transitive
     description:
@@ -1013,10 +1013,10 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.5"
   pub_semver:
     dependency: transitive
     description:
@@ -1053,10 +1053,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,9 +35,9 @@ dependencies:
   package_info_plus: ^8.1.0
   percent_indicator: 4.2.3
   permission_handler: ^11.3.1
-  pointycastle: 3.4.0
-  provider: ^6.1.2
-  shared_preferences: ^2.3.2
+  pointycastle: 3.7.0
+  provider: ^6.1.5
+  shared_preferences: ^2.5.3
   uni_links2: 0.6.0+2
   url_launcher: 6.0.20
   webview_flutter: 2.0.13


### PR DESCRIPTION
## Summary

This pull request completes the package migration work outlined in ticket CAAPP-430. It addresses the final set of dependencies: `point_castle`, `provider`, `shared_preferences`, and `uni_links2`.

It also corrects a small typo in the campus mobile Readme.md file.

While most packages were updated successfully, this PR also documents important limitations encountered with `point_castle` and `uni_links2`. The `point_castle` upgrade is blocked by the unmaintained `encrypt` package, and the `uni_links2` replacement (`applinks`) is blocked by a required Gradle update. These findings are noted to inform future dependency management efforts.

## Changelog

[Internal] [Change] - Complete final package migrations for CAAPP-430 and document blockers.

## Test Plan

To verify these changes, the following steps were performed:

1.  **Successful Build**: Ensured the project builds successfully on both Android and iOS platforms without any dependency resolution errors.
2.  **Static Analysis**: Ran the project's linter and static análisis tools to check for any new issues introduced by the package updates.