### PR TITLE
(CAAPP-420) Button Navigation Bar Overflow Fix

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -161,6 +161,13 @@ class CampusMobile extends StatelessWidget {
             // : RoutePaths.BottomNavigationBar,
         onGenerateRoute: campusMobileRouter.Router.generateRoute,
         navigatorObservers: [observer],
+        builder: (context, child) {
+          return SafeArea(
+            top: false,
+            bottom: true,
+            child: child!,
+          );
+        },
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,7 +158,6 @@ class CampusMobile extends StatelessWidget {
         initialRoute: showOnboardingScreen
             ? RoutePaths.OnboardingLogin
             : RoutePaths.BottomNavigationBar,
-            // : RoutePaths.BottomNavigationBar,
         onGenerateRoute: campusMobileRouter.Router.generateRoute,
         navigatorObservers: [observer],
         builder: (context, child) {


### PR DESCRIPTION
## Summary
Fixed RenderFlex overflow for Android phones using the button navigation. The bug was documented here: https://its-pro.ucsd.edu/browse/CAAPP-420 and it is ready for testing.

Solution: 
I got inspiration from this GitHub thread https://github.com/flutter/flutter/issues/170640#issuecomment-3051556142, which offered the following solution:
```
MaterialApp(
  builder: (context, child) {
    return SafeArea(
      top: false, // Set to true if you want to avoid notch overlap too
      bottom: true, // Avoids overlap with navigation bar
      child: child!,
    );
  },
  home: YourHomePage(), // Or your main screen
);
```

However, I realized that we are not using the normal `MaterialApp` - since we are using the GetX package.  
I had to find an equivalent solution that uses `GetMaterialApp`, and it turned out to be the one below (adding the `builder` property with `bottom` set to `true`:  
```
GetMaterialApp(
    // ... Assume current implementation here... //
    // Added the builder property
    builder: (context, child) {
          return SafeArea(
            top: false,
            bottom: true,
            child: child!,
          );
        },
```

## Changelog
[Android] [Fix] - Fixed a bug causing the bottom to overflow by 14 pixels.
<img width="764" height="416" alt="Screenshot 2025-08-20 081946" src="https://github.com/user-attachments/assets/ff125c50-9ba3-4f59-8d12-71c9d090f984" />

## Test Plan
Ensure the bottom doesn't overflow when using the `button` and the `gesture` navigation. The app should work as below:

https://github.com/user-attachments/assets/abbfd71b-7880-4dea-83b4-ec34d5f1ebb9


