### PR TITLE
(CAAPP-442) Upgrade permission_handler

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -925,18 +925,18 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "12.0.1"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "13.0.1"
   permission_handler_apple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   geolocator: 9.0.2
   package_info_plus: ^8.1.0
   percent_indicator: 4.2.3
-  permission_handler: ^11.3.1
+  permission_handler: ^12.0.1
   pointycastle: 3.4.0
   provider: ^6.1.2
   shared_preferences: ^2.3.2


### PR DESCRIPTION
## Summary
Upgraded Permission handler from `^11.3.1` to `^12.0.1`.

## Changelog
[General] [Change] - Upgraded Permission handler from `^11.3.1` to `^12.0.1` in pubspec.yaml


## Test Plan
Test all features that request or check permissions (location, camera, storage, etc.) on both Android and iOS.
Ensure permission dialogs appear and the app responds correctly to permission changes (granted, denied, restricted, etc.).

[Click here to go to PR 2226 Test Plan](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/Shared%20Documents/Campus%20Mobile%20Builds/Pull%20Request%20Testing/%5BCAAPP-408%5D-PR-Test-Plans-7.32.0-QA.xlsx?d=wf31ff1c0c767426baac18c35b718a994&csf=1&web=1&e=fJIG0v&nav=MTJfQTE0NTpFMTY3X3swMDAwMDAwMC0wMDAxLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDB9)
