### PR TITLE
(CAAPP-440) Upgrade intl

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -701,10 +701,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   google_maps_flutter: 2.10.1
   hive: 2.2.3
   hive_flutter: 1.1.0
-  intl: 0.19.0
+  intl: ^0.20.2
   liquid_progress_indicator_v2: 0.5.0
   measured_size: 1.0.0
   geolocator: 9.0.2


### PR DESCRIPTION
## Summary
Upgraded intl package from `0.19.0` to `^0.20.2`.

## Changelog
[General] [Change] - Upgraded intl package from `0.19.0` to `^0.20.2` in pubspec.yaml.

## Test Plan
Open all screens that display dates, times, or numbers (such as news, events, and any common widgets).
Verify that all formatted values appear correctly and as expected for your locale.
Change your device’s locale (language/region) and check that the app displays localized formats properly.

[Click here to go to PR 2227 Test Plan](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/Shared%20Documents/Campus%20Mobile%20Builds/Pull%20Request%20Testing/%5BCAAPP-408%5D-PR-Test-Plans-7.32.0-QA.xlsx?d=wf31ff1c0c767426baac18c35b718a994&csf=1&web=1&e=Z2Quh5&nav=MTJfQTE2OTpFMTkxX3swMDAwMDAwMC0wMDAxLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDB9)
