### PR TITLE
(CAAPP-430) Shared preferences upgrade

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1053,10 +1053,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   permission_handler: ^11.3.1
   pointycastle: 3.4.0
   provider: ^6.1.2
-  shared_preferences: ^2.3.2
+  shared_preferences: ^2.5.3
   uni_links2: 0.6.0+2
   url_launcher: 6.0.20
   webview_flutter: 2.0.13


### PR DESCRIPTION
## Summary
Upgraded shared_preferences from ^2.3.2 to ^2.5.3.



## Changelog
[General] [Change] - Upgraded shared_preferences from ^2.3.2 to ^2.5.3 in pubspec.yaml


## Test Plan
Shared_preferences is a library that allows the app to store small key value pairs that persist across app actions (like closing and opening, installing updates, restarting the app, etc). It is usually used to store user data.
Therefore, make sure you can log in properly and that all your data persists across different actions listed above.

[Test Plan for PR 2229](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/Shared%20Documents/Campus%20Mobile%20Builds/Pull%20Request%20Testing/%5BCAAPP-408%5D-PR-Test-Plans-7.32.0-QA.xlsx?d=wf31ff1c0c767426baac18c35b718a994&csf=1&web=1&e=5I7bzS&nav=MTJfQTE5MzpFMjE1X3swMDAwMDAwMC0wMDAxLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDB9)