### PR TITLE
[CAAP-453] iOS Black Space Under Navbar Fix

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_provider.dart';
 import 'package:campus_mobile_experimental/app_router.dart'
@@ -163,7 +164,7 @@ class CampusMobile extends StatelessWidget {
         builder: (context, child) {
           return SafeArea(
             top: false,
-            bottom: true,
+            bottom: Platform.isAndroid,
             child: child!,
           );
         },


### PR DESCRIPTION
## Summary
There is a black space under the navbar on iOS devices.


## Changelog
[iOS][Fix] - Add a check - if device is Android there will be a bottom safe area, if device is iOS, there won't be a bottom safe area. 

[Test Plan](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B82ACB10B-F3F6-412A-98C6-99B32C0ABF87%7D&file=PR-2231.xlsx&action=default&mobileredirect=true)
