### PR TITLE
[CAAP-418] - Add Parking Spots (EV, PV, 2 Person Carpool) 

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
 class RoutePaths {
   static const String Home = '/';
   static const String BottomNavigationBar = 'bottom_navigation_bar';
@@ -116,6 +119,10 @@ class ParkingConstants {
   static const lotMaxTitle = 'Maximum parking lots reached';
   static const lotMaxDesc =
       'You have reached the maximum number of lots (10) that can be selected. Please deselect some lots before adding more.';
+  static const Map<String, IconData> stringToIconData = {
+    'icon - e03e': Icons.accessible,
+    'icon - e486': Icons.group,
+  };
 }
 
 class WifiConstants {
@@ -124,7 +131,8 @@ class WifiConstants {
   static const wifiIssueFailedDesc = 'Please run speed test to report issue.';
   // Finished State
   static const wifiIssueSuccessTitle = 'Issue Reported';
-  static const wifiIssueSuccessDesc = 'Thank you for helping improve UCSD wireless. Your test results have been sent to IT Services.';
+  static const wifiIssueSuccessDesc =
+      'Thank you for helping improve UCSD wireless. Your test results have been sent to IT Services.';
 }
 
 class Plugins {

--- a/lib/core/models/spot_types.dart
+++ b/lib/core/models/spot_types.dart
@@ -29,15 +29,17 @@ class Spot {
   String spotKey;
   String name;
   String color;
-  String text;
+  String? text;
   String textColor;
+  String? icon;
 
   Spot({
     this.spotKey = '',
     this.name = '',
     this.color = '',
-    this.text = '',
-    this.textColor = ''
+    this.text,
+    this.textColor = '',
+    this.icon
   });
 
   factory Spot.fromJson(Map<String, dynamic> json) => Spot(
@@ -46,6 +48,7 @@ class Spot {
         color: json["color"],
         text: json["text"],
         textColor: json["text_color"],
+        icon: json["icon"],
   );
 
   Map<String, dynamic> toJson() => {
@@ -53,6 +56,7 @@ class Spot {
         "name": name,
         "color": color,
         "text": text,
-        "textColor": textColor
+        "text_color": textColor,
+        "icon": icon,
       };
 }

--- a/lib/core/models/spot_types.dart
+++ b/lib/core/models/spot_types.dart
@@ -16,13 +16,13 @@ class SpotTypeModel {
         spots: json["spots"] == null
             ? null
             : List<Spot>.from(json["spots"].map((x) => Spot.fromJson(x))),
-  );
+      );
 
   Map<String, dynamic> toJson() => {
         "spots": spots == null
             ? null
             : List<dynamic>.from(spots!.map((x) => x.toJson())),
-  };
+      };
 }
 
 class Spot {
@@ -46,7 +46,7 @@ class Spot {
         logoBackgroundColor: json["logo_background_color"] ?? '',
         logoText: json["logo_text"],
         logoTextColor: json["logo_text_color"] ?? '',
-  );
+      );
 
   Map<String, dynamic> toJson() => {
         "key": spotKey,

--- a/lib/core/models/spot_types.dart
+++ b/lib/core/models/spot_types.dart
@@ -44,7 +44,7 @@ class Spot {
         spotKey: json["key"] ?? '',
         name: json["name"] ?? '',
         logoBackgroundColor: json["logo_background_color"] ?? '',
-        logoText: json["logo_text"],
+        logoText: json["logo_text"] ?? '',
         logoTextColor: json["logo_text_color"] ?? '',
       );
 

--- a/lib/core/models/spot_types.dart
+++ b/lib/core/models/spot_types.dart
@@ -28,35 +28,31 @@ class SpotTypeModel {
 class Spot {
   String spotKey;
   String name;
-  String color;
-  String? text;
-  String textColor;
-  String? icon;
+  String logoBackgroundColor;
+  String logoText;
+  String logoTextColor;
 
   Spot({
     this.spotKey = '',
     this.name = '',
-    this.color = '',
-    this.text,
-    this.textColor = '',
-    this.icon
+    this.logoBackgroundColor = '',
+    this.logoText = '',
+    this.logoTextColor = '',
   });
 
   factory Spot.fromJson(Map<String, dynamic> json) => Spot(
-        spotKey: json["key"],
-        name: json["name"],
-        color: json["color"],
-        text: json["text"],
-        textColor: json["text_color"],
-        icon: json["icon"],
+        spotKey: json["key"] ?? '',
+        name: json["name"] ?? '',
+        logoBackgroundColor: json["logo_background_color"] ?? '',
+        logoText: json["logo_text"],
+        logoTextColor: json["logo_text_color"] ?? '',
   );
 
   Map<String, dynamic> toJson() => {
         "key": spotKey,
         "name": name,
-        "color": color,
-        "text": text,
-        "text_color": textColor,
-        "icon": icon,
+        "logo_background_color": logoBackgroundColor,
+        "logo_text": logoText,
+        "logo_text_color": logoTextColor,
       };
 }

--- a/lib/core/providers/parking.dart
+++ b/lib/core/providers/parking.dart
@@ -81,8 +81,9 @@ class ParkingDataProvider extends ChangeNotifier {
       }
       if (_userDataProvider.userProfileModel.selectedParkingSpots!.isNotEmpty) {
         // Load selected spots types from user Profile
-        _selectedSpotTypesState = _userDataProvider
-            .userProfileModel.selectedParkingSpots! as Map<String, bool>;
+        _selectedSpotTypesState = Map<String, bool>.from(
+          _userDataProvider.userProfileModel.selectedParkingSpots!,
+        );
       } else {
         // Load default spot types
         for (Spot spot in _spotTypeModel.spots!) {

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -139,17 +139,8 @@ class CircularParkingIndicators extends StatelessWidget {
                                                 fontWeight: FontWeight.w700,
                                               ),
                                             )
-                                          : Text(
-                                              '?',
-                                              style: TextStyle(
-                                                color: colorFromHex(
-                                                    spotType.logoTextColor),
-                                                fontFamily: 'Brix Sans',
-                                                fontWeight: FontWeight.w700,
-                                                fontSize: 28,
-                                              ),
-                                            )),
-                        )
+                                          : SizedBox.shrink()
+                        ))
                       : Container(),
                 )
               ],
@@ -222,17 +213,8 @@ class CircularParkingIndicators extends StatelessWidget {
                                                 fontSize: 28,
                                               ),
                                             )
-                                          : Text(
-                                              '?',
-                                              style: TextStyle(
-                                                color: colorFromHex(
-                                                    spotType.logoTextColor),
-                                                fontFamily: 'Brix Sans',
-                                                fontWeight: FontWeight.w700,
-                                                fontSize: 28,
-                                              ),
-                                            )),
-                        )
+                                          : SizedBox.shrink()
+                        ))
                       : Container(),
                 )
               ],

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -105,10 +105,15 @@ class CircularParkingIndicators extends StatelessWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: spotType != null
                       ? CircleAvatar(
-                          backgroundColor: colorFromHex(spotType.logoBackgroundColor),
+                          backgroundColor:
+                              colorFromHex(spotType.logoBackgroundColor),
                           child: spotType.logoText.startsWith('icon - ')
                               ? Icon(
-                                  IconData(int.parse(spotType.logoText.replaceFirst('icon - ', ''), radix: 16),
+                                  IconData(
+                                      int.parse(
+                                          spotType.logoText
+                                              .replaceFirst('icon - ', ''),
+                                          radix: 16),
                                       fontFamily: 'MaterialIcons'),
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
@@ -116,7 +121,8 @@ class CircularParkingIndicators extends StatelessWidget {
                                   ? Text(
                                       spotType.logoText,
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.logoTextColor),
+                                        color: colorFromHex(
+                                            spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontSize: 28,
                                         fontWeight: FontWeight.w700,
@@ -125,7 +131,8 @@ class CircularParkingIndicators extends StatelessWidget {
                                   : Text(
                                       '?',
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.logoTextColor),
+                                        color: colorFromHex(
+                                            spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontWeight: FontWeight.w700,
                                         fontSize: 28,
@@ -170,10 +177,15 @@ class CircularParkingIndicators extends StatelessWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: spotType != null
                       ? CircleAvatar(
-                          backgroundColor: colorFromHex(spotType.logoBackgroundColor),
+                          backgroundColor:
+                              colorFromHex(spotType.logoBackgroundColor),
                           child: spotType.logoText.startsWith('icon - ')
                               ? Icon(
-                                  IconData(int.parse(spotType.logoText.replaceFirst('icon - ', ''), radix: 16),
+                                  IconData(
+                                      int.parse(
+                                          spotType.logoText
+                                              .replaceFirst('icon - ', ''),
+                                          radix: 16),
                                       fontFamily: 'MaterialIcons'),
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
@@ -181,7 +193,8 @@ class CircularParkingIndicators extends StatelessWidget {
                                   ? Text(
                                       spotType.logoText,
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.logoTextColor),
+                                        color: colorFromHex(
+                                            spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontWeight: FontWeight.w700,
                                         fontSize: 28,
@@ -190,7 +203,8 @@ class CircularParkingIndicators extends StatelessWidget {
                                   : Text(
                                       '?',
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.logoTextColor),
+                                        color: colorFromHex(
+                                            spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontWeight: FontWeight.w700,
                                         fontSize: 28,

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -116,18 +116,19 @@ class CircularParkingIndicators extends StatelessWidget {
                                       size: 25.0,
                                       color:
                                           colorFromHex(spotType.logoTextColor))
-                                  : spotType.logoText.startsWith('icon - ')
-                                      ? Icon(
-                                          IconData(
-                                              int.parse(
-                                                  spotType.logoText
-                                                      .replaceFirst(
-                                                          'icon - ', ''),
-                                                  radix: 16),
-                                              fontFamily: 'MaterialIcons'),
-                                          size: 25.0,
-                                          color: colorFromHex(
-                                              spotType.logoTextColor))
+                                  // Load icon dynamically from MaterialIcons if prefixed with 'icon - '
+                                  // : spotType.logoText.startsWith('icon - ')
+                                  //     ? Icon(
+                                  //         IconData(
+                                  //             int.parse(
+                                  //                 spotType.logoText
+                                  //                     .replaceFirst(
+                                  //                         'icon - ', ''),
+                                  //                 radix: 16),
+                                  //             fontFamily: 'MaterialIcons'),
+                                  //         size: 25.0,
+                                  //         color: colorFromHex(
+                                  //             spotType.logoTextColor))
                                       : (spotType.logoText.isNotEmpty
                                           ? Text(
                                               spotType.logoText,
@@ -190,18 +191,19 @@ class CircularParkingIndicators extends StatelessWidget {
                                       size: 25.0,
                                       color:
                                           colorFromHex(spotType.logoTextColor))
-                                  : spotType.logoText.startsWith('icon - ')
-                                      ? Icon(
-                                          IconData(
-                                              int.parse(
-                                                  spotType.logoText
-                                                      .replaceFirst(
-                                                          'icon - ', ''),
-                                                  radix: 16),
-                                              fontFamily: 'MaterialIcons'),
-                                          size: 25.0,
-                                          color: colorFromHex(
-                                              spotType.logoTextColor))
+                                  // Load icon dynamically from MaterialIcons if prefixed with 'icon - '
+                                  // : spotType.logoText.startsWith('icon - ')
+                                  //     ? Icon(
+                                  //         IconData(
+                                  //             int.parse(
+                                  //                 spotType.logoText
+                                  //                     .replaceFirst(
+                                  //                         'icon - ', ''),
+                                  //                 radix: 16),
+                                  //             fontFamily: 'MaterialIcons'),
+                                  //         size: 25.0,
+                                  //         color: colorFromHex(
+                                  //             spotType.logoTextColor))
                                       : (spotType.logoText.isNotEmpty
                                           ? Text(
                                               spotType.logoText,

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -124,7 +124,15 @@ class CircularParkingIndicators extends StatelessWidget {
                                         fontWeight: FontWeight.w700,
                                       ),
                                     )
-                                  : SizedBox.shrink()),
+                                  : Text(
+                                      '?',
+                                      style: TextStyle(
+                                        color: colorFromHex(spotType.textColor),
+                                        fontFamily: 'Brix Sans',
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 28,
+                                      ),
+                                    )),
                         )
                       : Container(),
                 )
@@ -181,7 +189,15 @@ class CircularParkingIndicators extends StatelessWidget {
                                         fontSize: 28,
                                       ),
                                     )
-                                  : SizedBox.shrink()),
+                                  : Text(
+                                      '?',
+                                      style: TextStyle(
+                                        color: colorFromHex(spotType.textColor),
+                                        fontFamily: 'Brix Sans',
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 28,
+                                      ),
+                                    )),
                         )
                       : Container(),
                 )

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -106,21 +106,25 @@ class CircularParkingIndicators extends StatelessWidget {
                   child: spotType != null
                       ? CircleAvatar(
                           backgroundColor: colorFromHex(spotType.color),
-                          child: spotType.text.contains("&#x267f;")
+                          child: (spotType.text == null ||
+                                      spotType.text!.isEmpty) &&
+                                  spotType.icon != null
                               ? Icon(
-                                  Icons.accessible,
+                                  IconData(int.parse(spotType.icon!, radix: 16),
+                                      fontFamily: 'MaterialIcons'),
                                   size: 25.0,
-                                  color: colorFromHex(spotType.textColor),
-                                )
-                              : Text(
-                                  spotType.text,
-                                  style: TextStyle(
-                                    color: colorFromHex(spotType.textColor),
-                                    fontFamily: 'Brix Sans',
-                                    fontSize: 28,
-                                    fontWeight: FontWeight.w700,
-                                  ),
-                                ),
+                                  color: colorFromHex(spotType.textColor))
+                              : (spotType.text != null
+                                  ? Text(
+                                      spotType.text!,
+                                      style: TextStyle(
+                                        color: colorFromHex(spotType.textColor),
+                                        fontFamily: 'Brix Sans',
+                                        fontSize: 28,
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    )
+                                  : SizedBox.shrink()),
                         )
                       : Container(),
                 )
@@ -161,21 +165,23 @@ class CircularParkingIndicators extends StatelessWidget {
                   child: spotType != null
                       ? CircleAvatar(
                           backgroundColor: colorFromHex(spotType.color),
-                          child: spotType.text.contains("&#x267f;")
+                          child: spotType.text == null && spotType.icon != null
                               ? Icon(
-                                  Icons.accessible,
+                                  IconData(int.parse(spotType.icon!, radix: 16),
+                                      fontFamily: 'MaterialIcons'),
                                   size: 25.0,
-                                  color: colorFromHex(spotType.textColor),
-                                )
-                              : Text(
-                                  spotType.text,
-                                  style: TextStyle(
-                                    color: colorFromHex(spotType.textColor),
-                                    fontFamily: 'Brix Sans',
-                                    fontWeight: FontWeight.w700,
-                                    fontSize: 28,
-                                  ),
-                                ),
+                                  color: colorFromHex(spotType.textColor))
+                              : (spotType.text != null
+                                  ? Text(
+                                      spotType.text!,
+                                      style: TextStyle(
+                                        color: colorFromHex(spotType.textColor),
+                                        fontFamily: 'Brix Sans',
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 28,
+                                      ),
+                                    )
+                                  : SizedBox.shrink()),
                         )
                       : Container(),
                 )

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -105,18 +105,18 @@ class CircularParkingIndicators extends StatelessWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: spotType != null
                       ? CircleAvatar(
-                          backgroundColor: colorFromHex(spotType.color),
-                          child: (spotType.text == null || spotType.text!.isEmpty) && (spotType.icon != null && spotType.icon!.isNotEmpty)
+                          backgroundColor: colorFromHex(spotType.logoBackgroundColor),
+                          child: spotType.logoText.startsWith('icon - ')
                               ? Icon(
-                                  IconData(int.parse(spotType.icon!, radix: 16),
+                                  IconData(int.parse(spotType.logoText.replaceFirst('icon - ', ''), radix: 16),
                                       fontFamily: 'MaterialIcons'),
                                   size: 25.0,
-                                  color: colorFromHex(spotType.textColor))
-                              : (spotType.text != null && spotType.text!.isNotEmpty
+                                  color: colorFromHex(spotType.logoTextColor))
+                              : (spotType.logoText.isNotEmpty
                                   ? Text(
-                                      spotType.text!,
+                                      spotType.logoText,
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.textColor),
+                                        color: colorFromHex(spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontSize: 28,
                                         fontWeight: FontWeight.w700,
@@ -125,7 +125,7 @@ class CircularParkingIndicators extends StatelessWidget {
                                   : Text(
                                       '?',
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.textColor),
+                                        color: colorFromHex(spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontWeight: FontWeight.w700,
                                         fontSize: 28,
@@ -170,18 +170,18 @@ class CircularParkingIndicators extends StatelessWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: spotType != null
                       ? CircleAvatar(
-                          backgroundColor: colorFromHex(spotType.color),
-                          child: (spotType.text == null || spotType.text!.isEmpty) && (spotType.icon != null && spotType.icon!.isNotEmpty)
+                          backgroundColor: colorFromHex(spotType.logoBackgroundColor),
+                          child: spotType.logoText.startsWith('icon - ')
                               ? Icon(
-                                  IconData(int.parse(spotType.icon!, radix: 16),
+                                  IconData(int.parse(spotType.logoText.replaceFirst('icon - ', ''), radix: 16),
                                       fontFamily: 'MaterialIcons'),
                                   size: 25.0,
-                                  color: colorFromHex(spotType.textColor))
-                              : (spotType.text != null && spotType.text!.isNotEmpty
+                                  color: colorFromHex(spotType.logoTextColor))
+                              : (spotType.logoText.isNotEmpty
                                   ? Text(
-                                      spotType.text!,
+                                      spotType.logoText,
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.textColor),
+                                        color: colorFromHex(spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontWeight: FontWeight.w700,
                                         fontSize: 28,
@@ -190,7 +190,7 @@ class CircularParkingIndicators extends StatelessWidget {
                                   : Text(
                                       '?',
                                       style: TextStyle(
-                                        color: colorFromHex(spotType.textColor),
+                                        color: colorFromHex(spotType.logoTextColor),
                                         fontFamily: 'Brix Sans',
                                         fontWeight: FontWeight.w700,
                                         fontSize: 28,

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -1,9 +1,12 @@
 import 'package:campus_mobile_experimental/core/models/parking.dart';
+import 'package:campus_mobile_experimental/core/models/shuttle.dart';
 import 'package:campus_mobile_experimental/core/models/spot_types.dart';
 import 'package:campus_mobile_experimental/core/providers/parking.dart';
 import 'package:flutter/material.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 import 'package:provider/provider.dart';
+
+import '../../app_constants.dart';
 
 class CircularParkingIndicators extends StatelessWidget {
   const CircularParkingIndicators({
@@ -107,41 +110,25 @@ class CircularParkingIndicators extends StatelessWidget {
                       ? CircleAvatar(
                           backgroundColor:
                               colorFromHex(spotType.logoBackgroundColor),
-                          child: spotType.logoText == 'icon - e486'
-                              ? Icon(Icons.group,
+                          child: spotType.logoText.startsWith('icon - ')
+                              ? Icon(
+                                  ParkingConstants.stringToIconData[
+                                          spotType.logoText] ??
+                                      Icons.error,
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
-                              : spotType.logoText == 'icon - e03e'
-                                  ? Icon(Icons.accessible,
-                                      size: 25.0,
-                                      color:
-                                          colorFromHex(spotType.logoTextColor))
-                                  // Load icon dynamically from MaterialIcons if prefixed with 'icon - '
-                                  // : spotType.logoText.startsWith('icon - ')
-                                  //     ? Icon(
-                                  //         IconData(
-                                  //             int.parse(
-                                  //                 spotType.logoText
-                                  //                     .replaceFirst(
-                                  //                         'icon - ', ''),
-                                  //                 radix: 16),
-                                  //             fontFamily: 'MaterialIcons'),
-                                  //         size: 25.0,
-                                  //         color: colorFromHex(
-                                  //             spotType.logoTextColor))
-                                      : (spotType.logoText.isNotEmpty
-                                          ? Text(
-                                              spotType.logoText,
-                                              style: TextStyle(
-                                                color: colorFromHex(
-                                                    spotType.logoTextColor),
-                                                fontFamily: 'Brix Sans',
-                                                fontSize: 28,
-                                                fontWeight: FontWeight.w700,
-                                              ),
-                                            )
-                                          : SizedBox.shrink()
-                        ))
+                              : (spotType.logoText.isNotEmpty
+                                  ? Text(
+                                      spotType.logoText,
+                                      style: TextStyle(
+                                        color: colorFromHex(
+                                            spotType.logoTextColor),
+                                        fontFamily: 'Brix Sans',
+                                        fontSize: 28,
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    )
+                                  : SizedBox.shrink()))
                       : Container(),
                 )
               ],
@@ -182,41 +169,25 @@ class CircularParkingIndicators extends StatelessWidget {
                       ? CircleAvatar(
                           backgroundColor:
                               colorFromHex(spotType.logoBackgroundColor),
-                          child: spotType.logoText == 'icon - e486'
-                              ? Icon(Icons.group,
+                          child: spotType.logoText.startsWith('icon - ')
+                              ? Icon(
+                                  ParkingConstants.stringToIconData[
+                                          spotType.logoText] ??
+                                      Icons.error,
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
-                              : spotType.logoText == 'icon - e03e'
-                                  ? Icon(Icons.accessible,
-                                      size: 25.0,
-                                      color:
-                                          colorFromHex(spotType.logoTextColor))
-                                  // Load icon dynamically from MaterialIcons if prefixed with 'icon - '
-                                  // : spotType.logoText.startsWith('icon - ')
-                                  //     ? Icon(
-                                  //         IconData(
-                                  //             int.parse(
-                                  //                 spotType.logoText
-                                  //                     .replaceFirst(
-                                  //                         'icon - ', ''),
-                                  //                 radix: 16),
-                                  //             fontFamily: 'MaterialIcons'),
-                                  //         size: 25.0,
-                                  //         color: colorFromHex(
-                                  //             spotType.logoTextColor))
-                                      : (spotType.logoText.isNotEmpty
-                                          ? Text(
-                                              spotType.logoText,
-                                              style: TextStyle(
-                                                color: colorFromHex(
-                                                    spotType.logoTextColor),
-                                                fontFamily: 'Brix Sans',
-                                                fontWeight: FontWeight.w700,
-                                                fontSize: 28,
-                                              ),
-                                            )
-                                          : SizedBox.shrink()
-                        ))
+                              : (spotType.logoText.isNotEmpty
+                                  ? Text(
+                                      spotType.logoText,
+                                      style: TextStyle(
+                                        color: colorFromHex(
+                                            spotType.logoTextColor),
+                                        fontFamily: 'Brix Sans',
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 28,
+                                      ),
+                                    )
+                                  : SizedBox.shrink()))
                       : Container(),
                 )
               ],

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -108,25 +108,26 @@ class CircularParkingIndicators extends StatelessWidget {
                           backgroundColor:
                               colorFromHex(spotType.logoBackgroundColor),
                           child: spotType.logoText == 'icon - e486'
-                              ? Icon(
-                                  IconData(0xe486, fontFamily: 'MaterialIcons'),
+                              ? Icon(Icons.group,
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
                               : spotType.logoText == 'icon - e03e'
-                                  ? Icon(
-                                      IconData(0xe03e, fontFamily: 'MaterialIcons'),
+                                  ? Icon(Icons.accessible,
                                       size: 25.0,
-                                      color: colorFromHex(spotType.logoTextColor))
+                                      color:
+                                          colorFromHex(spotType.logoTextColor))
                                   : spotType.logoText.startsWith('icon - ')
                                       ? Icon(
                                           IconData(
                                               int.parse(
                                                   spotType.logoText
-                                                      .replaceFirst('icon - ', ''),
+                                                      .replaceFirst(
+                                                          'icon - ', ''),
                                                   radix: 16),
-                                          fontFamily: 'MaterialIcons'),
+                                              fontFamily: 'MaterialIcons'),
                                           size: 25.0,
-                                          color: colorFromHex(spotType.logoTextColor))
+                                          color: colorFromHex(
+                                              spotType.logoTextColor))
                                       : (spotType.logoText.isNotEmpty
                                           ? Text(
                                               spotType.logoText,
@@ -190,25 +191,26 @@ class CircularParkingIndicators extends StatelessWidget {
                           backgroundColor:
                               colorFromHex(spotType.logoBackgroundColor),
                           child: spotType.logoText == 'icon - e486'
-                              ? Icon(
-                                  IconData(0xe486, fontFamily: 'MaterialIcons'),
+                              ? Icon(Icons.group,
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
                               : spotType.logoText == 'icon - e03e'
-                                  ? Icon(
-                                      IconData(0xe03e, fontFamily: 'MaterialIcons'),
+                                  ? Icon(Icons.accessible,
                                       size: 25.0,
-                                      color: colorFromHex(spotType.logoTextColor))
+                                      color:
+                                          colorFromHex(spotType.logoTextColor))
                                   : spotType.logoText.startsWith('icon - ')
                                       ? Icon(
                                           IconData(
                                               int.parse(
                                                   spotType.logoText
-                                                      .replaceFirst('icon - ', ''),
+                                                      .replaceFirst(
+                                                          'icon - ', ''),
                                                   radix: 16),
-                                          fontFamily: 'MaterialIcons'),
+                                              fontFamily: 'MaterialIcons'),
                                           size: 25.0,
-                                          color: colorFromHex(spotType.logoTextColor))
+                                          color: colorFromHex(
+                                              spotType.logoTextColor))
                                       : (spotType.logoText.isNotEmpty
                                           ? Text(
                                               spotType.logoText,

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -106,15 +106,13 @@ class CircularParkingIndicators extends StatelessWidget {
                   child: spotType != null
                       ? CircleAvatar(
                           backgroundColor: colorFromHex(spotType.color),
-                          child: (spotType.text == null ||
-                                      spotType.text!.isEmpty) &&
-                                  spotType.icon != null
+                          child: (spotType.text == null || spotType.text!.isEmpty) && (spotType.icon != null && spotType.icon!.isNotEmpty)
                               ? Icon(
                                   IconData(int.parse(spotType.icon!, radix: 16),
                                       fontFamily: 'MaterialIcons'),
                                   size: 25.0,
                                   color: colorFromHex(spotType.textColor))
-                              : (spotType.text != null
+                              : (spotType.text != null && spotType.text!.isNotEmpty
                                   ? Text(
                                       spotType.text!,
                                       style: TextStyle(
@@ -173,13 +171,13 @@ class CircularParkingIndicators extends StatelessWidget {
                   child: spotType != null
                       ? CircleAvatar(
                           backgroundColor: colorFromHex(spotType.color),
-                          child: spotType.text == null && spotType.icon != null
+                          child: (spotType.text == null || spotType.text!.isEmpty) && (spotType.icon != null && spotType.icon!.isNotEmpty)
                               ? Icon(
                                   IconData(int.parse(spotType.icon!, radix: 16),
                                       fontFamily: 'MaterialIcons'),
                                   size: 25.0,
                                   color: colorFromHex(spotType.textColor))
-                              : (spotType.text != null
+                              : (spotType.text != null && spotType.text!.isNotEmpty
                                   ? Text(
                                       spotType.text!,
                                       style: TextStyle(

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -107,37 +107,47 @@ class CircularParkingIndicators extends StatelessWidget {
                       ? CircleAvatar(
                           backgroundColor:
                               colorFromHex(spotType.logoBackgroundColor),
-                          child: spotType.logoText.startsWith('icon - ')
+                          child: spotType.logoText == 'icon - e486'
                               ? Icon(
-                                  IconData(
-                                      int.parse(
-                                          spotType.logoText
-                                              .replaceFirst('icon - ', ''),
-                                          radix: 16),
-                                      fontFamily: 'MaterialIcons'),
+                                  IconData(0xe486, fontFamily: 'MaterialIcons'),
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
-                              : (spotType.logoText.isNotEmpty
-                                  ? Text(
-                                      spotType.logoText,
-                                      style: TextStyle(
-                                        color: colorFromHex(
-                                            spotType.logoTextColor),
-                                        fontFamily: 'Brix Sans',
-                                        fontSize: 28,
-                                        fontWeight: FontWeight.w700,
-                                      ),
-                                    )
-                                  : Text(
-                                      '?',
-                                      style: TextStyle(
-                                        color: colorFromHex(
-                                            spotType.logoTextColor),
-                                        fontFamily: 'Brix Sans',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 28,
-                                      ),
-                                    )),
+                              : spotType.logoText == 'icon - e03e'
+                                  ? Icon(
+                                      IconData(0xe03e, fontFamily: 'MaterialIcons'),
+                                      size: 25.0,
+                                      color: colorFromHex(spotType.logoTextColor))
+                                  : spotType.logoText.startsWith('icon - ')
+                                      ? Icon(
+                                          IconData(
+                                              int.parse(
+                                                  spotType.logoText
+                                                      .replaceFirst('icon - ', ''),
+                                                  radix: 16),
+                                          fontFamily: 'MaterialIcons'),
+                                          size: 25.0,
+                                          color: colorFromHex(spotType.logoTextColor))
+                                      : (spotType.logoText.isNotEmpty
+                                          ? Text(
+                                              spotType.logoText,
+                                              style: TextStyle(
+                                                color: colorFromHex(
+                                                    spotType.logoTextColor),
+                                                fontFamily: 'Brix Sans',
+                                                fontSize: 28,
+                                                fontWeight: FontWeight.w700,
+                                              ),
+                                            )
+                                          : Text(
+                                              '?',
+                                              style: TextStyle(
+                                                color: colorFromHex(
+                                                    spotType.logoTextColor),
+                                                fontFamily: 'Brix Sans',
+                                                fontWeight: FontWeight.w700,
+                                                fontSize: 28,
+                                              ),
+                                            )),
                         )
                       : Container(),
                 )
@@ -179,37 +189,47 @@ class CircularParkingIndicators extends StatelessWidget {
                       ? CircleAvatar(
                           backgroundColor:
                               colorFromHex(spotType.logoBackgroundColor),
-                          child: spotType.logoText.startsWith('icon - ')
+                          child: spotType.logoText == 'icon - e486'
                               ? Icon(
-                                  IconData(
-                                      int.parse(
-                                          spotType.logoText
-                                              .replaceFirst('icon - ', ''),
-                                          radix: 16),
-                                      fontFamily: 'MaterialIcons'),
+                                  IconData(0xe486, fontFamily: 'MaterialIcons'),
                                   size: 25.0,
                                   color: colorFromHex(spotType.logoTextColor))
-                              : (spotType.logoText.isNotEmpty
-                                  ? Text(
-                                      spotType.logoText,
-                                      style: TextStyle(
-                                        color: colorFromHex(
-                                            spotType.logoTextColor),
-                                        fontFamily: 'Brix Sans',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 28,
-                                      ),
-                                    )
-                                  : Text(
-                                      '?',
-                                      style: TextStyle(
-                                        color: colorFromHex(
-                                            spotType.logoTextColor),
-                                        fontFamily: 'Brix Sans',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 28,
-                                      ),
-                                    )),
+                              : spotType.logoText == 'icon - e03e'
+                                  ? Icon(
+                                      IconData(0xe03e, fontFamily: 'MaterialIcons'),
+                                      size: 25.0,
+                                      color: colorFromHex(spotType.logoTextColor))
+                                  : spotType.logoText.startsWith('icon - ')
+                                      ? Icon(
+                                          IconData(
+                                              int.parse(
+                                                  spotType.logoText
+                                                      .replaceFirst('icon - ', ''),
+                                                  radix: 16),
+                                          fontFamily: 'MaterialIcons'),
+                                          size: 25.0,
+                                          color: colorFromHex(spotType.logoTextColor))
+                                      : (spotType.logoText.isNotEmpty
+                                          ? Text(
+                                              spotType.logoText,
+                                              style: TextStyle(
+                                                color: colorFromHex(
+                                                    spotType.logoTextColor),
+                                                fontFamily: 'Brix Sans',
+                                                fontWeight: FontWeight.w700,
+                                                fontSize: 28,
+                                              ),
+                                            )
+                                          : Text(
+                                              '?',
+                                              style: TextStyle(
+                                                color: colorFromHex(
+                                                    spotType.logoTextColor),
+                                                fontFamily: 'Brix Sans',
+                                                fontWeight: FontWeight.w700,
+                                                fontSize: 28,
+                                              ),
+                                            )),
                         )
                       : Container(),
                 )

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -75,7 +75,9 @@ class _SpotTypesViewState extends State<SpotTypesView> {
                 alignment: Alignment.center,
                 child: data.logoText.startsWith('icon - ')
                     ? Icon(
-                        IconData(int.parse(data.logoText.replaceFirst('icon - ', ''), radix: 16),
+                        IconData(
+                            int.parse(data.logoText.replaceFirst('icon - ', ''),
+                                radix: 16),
                             fontFamily: 'MaterialIcons'),
                         size: 25.0,
                         color: textColor)

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -74,19 +74,15 @@ class _SpotTypesViewState extends State<SpotTypesView> {
               child: Align(
                 alignment: Alignment.center,
                 child: data.logoText == 'icon - e486'
-                    ? Icon(
-                        IconData(0xe486, fontFamily: 'MaterialIcons'),
-                        size: 25.0,
-                        color: textColor)
+                    ? Icon(Icons.group, size: 25.0, color: textColor)
                     : data.logoText == 'icon - e03e'
-                        ? Icon(
-                            IconData(0xe03e, fontFamily: 'MaterialIcons'),
-                            size: 25.0,
-                            color: textColor)
+                        ? Icon(Icons.accessible, size: 25.0, color: textColor)
                         : data.logoText.startsWith('icon - ')
                             ? Icon(
                                 IconData(
-                                    int.parse(data.logoText.replaceFirst('icon - ', ''),
+                                    int.parse(
+                                        data.logoText
+                                            .replaceFirst('icon - ', ''),
                                         radix: 16),
                                     fontFamily: 'MaterialIcons'),
                                 size: 25.0,

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -6,7 +6,7 @@ import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../app_constants.dart';
+import 'package:campus_mobile_experimental/app_constants.dart';
 import '../common/alert_dialog_widget.dart';
 
 class SpotTypesView extends StatefulWidget {
@@ -72,34 +72,24 @@ class _SpotTypesViewState extends State<SpotTypesView> {
                 color: iconColor,
               ),
               child: Align(
-                alignment: Alignment.center,
-                child: data.logoText == 'icon - e486'
-                    ? Icon(Icons.group, size: 25.0, color: textColor)
-                    : data.logoText == 'icon - e03e'
-                        ? Icon(Icons.accessible, size: 25.0, color: textColor)
-                        // Load icon dynamically from MaterialIcons if prefixed with 'icon - '
-                        // : data.logoText.startsWith('icon - ')
-                        //     ? Icon(
-                        //         IconData(
-                        //             int.parse(
-                        //                 data.logoText
-                        //                     .replaceFirst('icon - ', ''),
-                        //                 radix: 16),
-                        //             fontFamily: 'MaterialIcons'),
-                        //         size: 25.0,
-                        //         color: textColor)
-                            : (data.logoText.isNotEmpty
-                                ? Text(
-                                    data.logoText,
-                                    style: TextStyle(
-                                      color: textColor,
-                                      fontFamily: 'Brix Sans',
-                                      fontWeight: FontWeight.w700,
-                                      fontSize: 28,
-                                    ),
-                                  )
-                                : SizedBox.shrink()
-              ))),
+                  alignment: Alignment.center,
+                  child: data.logoText.startsWith('icon - ')
+                      ? Icon(
+                          ParkingConstants.stringToIconData[data.logoText] ??
+                              Icons.error,
+                          size: 25.0,
+                          color: textColor)
+                      : (data.logoText.isNotEmpty
+                          ? Text(
+                              data.logoText,
+                              style: TextStyle(
+                                color: textColor,
+                                fontFamily: 'Brix Sans',
+                                fontWeight: FontWeight.w700,
+                                fontSize: 28,
+                              ),
+                            )
+                          : SizedBox.shrink()))),
           title: Text(
             data.name,
             style: Theme.of(context).textTheme.bodyMedium,

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -65,19 +65,29 @@ class _SpotTypesViewState extends State<SpotTypesView> {
         ListTile(
           key: Key(data.name.toString()),
           leading: Container(
-            width: 35,
-            height: 35,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: iconColor,
-            ),
-            child: Align(
-              alignment: Alignment.center,
-              child: data.text.contains("&#x267f;")
-                  ? Icon(Icons.accessible, size: 25.0, color: textColor)
-                  : Text(data.text, style: TextStyle(color: textColor)),
-            ),
-          ),
+              width: 35,
+              height: 35,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: iconColor,
+              ),
+              child: Align(
+                alignment: Alignment.center,
+                child: data.text == null && data.icon != null
+                    ? Icon(
+                        IconData(int.parse(data.icon!, radix: 16),
+                            fontFamily: 'MaterialIcons'),
+                        size: 25.0,
+                        color: textColor)
+                    : (data.text != null
+                        ? Text(
+                            data.text!,
+                            style: TextStyle(
+                              color: textColor,
+                            ),
+                          )
+                        : SizedBox.shrink()),
+              )),
           title: Text(
             data.name,
             style: Theme.of(context).textTheme.bodyMedium,
@@ -104,7 +114,8 @@ class _SpotTypesViewState extends State<SpotTypesView> {
                   );
                   return;
                 }
-                spotTypesDataProvider.toggleSpotSelection(data.spotKey, selectedSpots);
+                spotTypesDataProvider.toggleSpotSelection(
+                    data.spotKey, selectedSpots);
               },
               activeColor: toggleActiveColor,
               trackColor: Colors.grey.shade400,

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -73,33 +73,43 @@ class _SpotTypesViewState extends State<SpotTypesView> {
               ),
               child: Align(
                 alignment: Alignment.center,
-                child: data.logoText.startsWith('icon - ')
+                child: data.logoText == 'icon - e486'
                     ? Icon(
-                        IconData(
-                            int.parse(data.logoText.replaceFirst('icon - ', ''),
-                                radix: 16),
-                            fontFamily: 'MaterialIcons'),
+                        IconData(0xe486, fontFamily: 'MaterialIcons'),
                         size: 25.0,
                         color: textColor)
-                    : (data.logoText.isNotEmpty
-                        ? Text(
-                            data.logoText,
-                            style: TextStyle(
-                              color: textColor,
-                              fontFamily: 'Brix Sans',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 28,
-                            ),
-                          )
-                        : Text(
-                            '?',
-                            style: TextStyle(
-                              color: textColor,
-                              fontFamily: 'Brix Sans',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 28,
-                            ),
-                          )),
+                    : data.logoText == 'icon - e03e'
+                        ? Icon(
+                            IconData(0xe03e, fontFamily: 'MaterialIcons'),
+                            size: 25.0,
+                            color: textColor)
+                        : data.logoText.startsWith('icon - ')
+                            ? Icon(
+                                IconData(
+                                    int.parse(data.logoText.replaceFirst('icon - ', ''),
+                                        radix: 16),
+                                    fontFamily: 'MaterialIcons'),
+                                size: 25.0,
+                                color: textColor)
+                            : (data.logoText.isNotEmpty
+                                ? Text(
+                                    data.logoText,
+                                    style: TextStyle(
+                                      color: textColor,
+                                      fontFamily: 'Brix Sans',
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 28,
+                                    ),
+                                  )
+                                : Text(
+                                    '?',
+                                    style: TextStyle(
+                                      color: textColor,
+                                      fontFamily: 'Brix Sans',
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 28,
+                                    ),
+                                  )),
               )),
           title: Text(
             data.name,

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../app_constants.dart';
 import '../common/alert_dialog_widget.dart';
+import 'circular_parking_indicator.dart';
 
 class SpotTypesView extends StatefulWidget {
   @override
@@ -86,7 +87,15 @@ class _SpotTypesViewState extends State<SpotTypesView> {
                               color: textColor,
                             ),
                           )
-                        : SizedBox.shrink()),
+                        : Text(
+                            '?',
+                            style: TextStyle(
+                              color: colorFromHex(data.textColor),
+                              fontFamily: 'Brix Sans',
+                              fontWeight: FontWeight.w700,
+                              fontSize: 28,
+                            ),
+                          )),
               )),
           title: Text(
             data.name,

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -97,16 +97,8 @@ class _SpotTypesViewState extends State<SpotTypesView> {
                                       fontSize: 28,
                                     ),
                                   )
-                                : Text(
-                                    '?',
-                                    style: TextStyle(
-                                      color: textColor,
-                                      fontFamily: 'Brix Sans',
-                                      fontWeight: FontWeight.w700,
-                                      fontSize: 28,
-                                    ),
-                                  )),
-              )),
+                                : SizedBox.shrink()
+              ))),
           title: Text(
             data.name,
             style: Theme.of(context).textTheme.bodyMedium,

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -77,16 +77,17 @@ class _SpotTypesViewState extends State<SpotTypesView> {
                     ? Icon(Icons.group, size: 25.0, color: textColor)
                     : data.logoText == 'icon - e03e'
                         ? Icon(Icons.accessible, size: 25.0, color: textColor)
-                        : data.logoText.startsWith('icon - ')
-                            ? Icon(
-                                IconData(
-                                    int.parse(
-                                        data.logoText
-                                            .replaceFirst('icon - ', ''),
-                                        radix: 16),
-                                    fontFamily: 'MaterialIcons'),
-                                size: 25.0,
-                                color: textColor)
+                        // Load icon dynamically from MaterialIcons if prefixed with 'icon - '
+                        // : data.logoText.startsWith('icon - ')
+                        //     ? Icon(
+                        //         IconData(
+                        //             int.parse(
+                        //                 data.logoText
+                        //                     .replaceFirst('icon - ', ''),
+                        //                 radix: 16),
+                        //             fontFamily: 'MaterialIcons'),
+                        //         size: 25.0,
+                        //         color: textColor)
                             : (data.logoText.isNotEmpty
                                 ? Text(
                                     data.logoText,

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -74,13 +74,14 @@ class _SpotTypesViewState extends State<SpotTypesView> {
               ),
               child: Align(
                 alignment: Alignment.center,
-                child: data.text == null && data.icon != null
+                child: (data.text == null || data.text!.isEmpty) &&
+                        (data.icon != null && data.icon!.isNotEmpty)
                     ? Icon(
                         IconData(int.parse(data.icon!, radix: 16),
                             fontFamily: 'MaterialIcons'),
                         size: 25.0,
                         color: textColor)
-                    : (data.text != null
+                    : (data.text != null && data.text!.isNotEmpty
                         ? Text(
                             data.text!,
                             style: TextStyle(

--- a/lib/ui/parking/spot_types_view.dart
+++ b/lib/ui/parking/spot_types_view.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../app_constants.dart';
 import '../common/alert_dialog_widget.dart';
-import 'circular_parking_indicator.dart';
 
 class SpotTypesView extends StatefulWidget {
   @override
@@ -59,8 +58,8 @@ class _SpotTypesViewState extends State<SpotTypesView> {
       var isSelected = Provider.of<ParkingDataProvider>(context)
           .spotTypesState[data.spotKey]!;
 
-      var iconColor = HexColor(data.color);
-      var textColor = HexColor(data.textColor);
+      var iconColor = HexColor(data.logoBackgroundColor);
+      var textColor = HexColor(data.logoTextColor);
 
       list.add(
         ListTile(
@@ -74,24 +73,26 @@ class _SpotTypesViewState extends State<SpotTypesView> {
               ),
               child: Align(
                 alignment: Alignment.center,
-                child: (data.text == null || data.text!.isEmpty) &&
-                        (data.icon != null && data.icon!.isNotEmpty)
+                child: data.logoText.startsWith('icon - ')
                     ? Icon(
-                        IconData(int.parse(data.icon!, radix: 16),
+                        IconData(int.parse(data.logoText.replaceFirst('icon - ', ''), radix: 16),
                             fontFamily: 'MaterialIcons'),
                         size: 25.0,
                         color: textColor)
-                    : (data.text != null && data.text!.isNotEmpty
+                    : (data.logoText.isNotEmpty
                         ? Text(
-                            data.text!,
+                            data.logoText,
                             style: TextStyle(
                               color: textColor,
+                              fontFamily: 'Brix Sans',
+                              fontWeight: FontWeight.w700,
+                              fontSize: 28,
                             ),
                           )
                         : Text(
                             '?',
                             style: TextStyle(
-                              color: colorFromHex(data.textColor),
+                              color: textColor,
                               fontFamily: 'Brix Sans',
                               fontWeight: FontWeight.w700,
                               fontSize: 28,


### PR DESCRIPTION
## Summary
Currently the mobile app doesn't show EV, PV and 2 Person Carpool spot types.   

<img width="341" height="443" alt="Screenshot 2025-08-12 at 3 04 44 PM" src="https://github.com/user-attachments/assets/161b1629-768b-4ee6-a8fb-da2b0fb4c2c0" />
<img width="336" height="432" alt="Screenshot 2025-08-12 at 3 04 48 PM" src="https://github.com/user-attachments/assets/1708add6-d8ba-4b3b-82cf-7edc8ef822d9" />
<img width="355" height="612" alt="Screenshot 2025-08-12 at 3 04 54 PM" src="https://github.com/user-attachments/assets/377b74fa-a595-4360-a183-b10505f09782" />

**NEW SINCE PR 2214 BELOW: **  

- Updated the spot types JSON to contain more descriptive variable names.
- Updated the spot types JSON to only have a `text` field for both text and icons. If there's an icon, then the value in the `text` field would be `icon - e486` where `e486` would be the hex that represents the icon for that piece of data.
- Updated the model to match this new JSON schema.
- Updated the logic inside `circular_parking_indicator.dart` and `spot_types_view.dart` to include the two new logos that we are using (for Accessible and 2 Person Carpool).
- This PR used to have a "dynamic" way to load the icons from the JSON, but the build **fails when trying to use `IconData` to render whatever icon is found in the JSON**. So the dynamic way of doing it was left as a comment and implemented a static way instead (since it's only two icons for now).

## Changelog
[General] [Add] - Since 2P Carpool is an icon, this adds logic so the app shows the it as an icon (2 person). 

## Test Plan  

- Ensure `Accessible` and `2 Person Carpool` logos display on the Parking Card.
- Ensure Parking card still works as expected (loads, re-loads, you can add/remove parking structures, change spots, etc).


[Test Plan for Android](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B80881769-0013-41C2-8D7B-254BEE9542E7%7D&file=PR-2236-Test-Plan-7.32.0-QA-4311.xlsx&action=default&mobileredirect=true)


[Test Plan for iOS](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7BC082444A-00C5-4943-9772-E9BE4D1F2E1C%7D&file=PR-2236-Test-Plan-7.32.0-QA-4310.xlsx&action=default&mobileredirect=true)


