### PR TITLE
[CAAPP-459] Add check map search

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -110,6 +110,10 @@ class LoginConstants {
   static const shuttleMaxTitle = 'Maximum shuttle stops reached';
   static const shuttleMaxDesc =
       'The maximum number of shuttle stops allowed is five. Please remove some stops to add more.';
+
+  static const mapSearchMinTitle = "Error Searching";
+  static const mapSearchMinDesc = "Enter at least 3 characters to search. ";
+
 }
 
 class ParkingConstants {

--- a/lib/ui/map/search_bar.dart
+++ b/lib/ui/map/search_bar.dart
@@ -2,8 +2,8 @@ import 'package:campus_mobile_experimental/core/providers/map.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../app_constants.dart';
-import '../common/alert_dialog_widget.dart';
+import 'package:campus_mobile_experimental/app_constants.dart';
+import 'package:campus_mobile_experimental/ui/common/alert_dialog_widget.dart';
 
 class MapSearchBar extends StatelessWidget {
   const MapSearchBar({

--- a/lib/ui/map/search_bar.dart
+++ b/lib/ui/map/search_bar.dart
@@ -2,6 +2,9 @@ import 'package:campus_mobile_experimental/core/providers/map.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../app_constants.dart';
+import '../common/alert_dialog_widget.dart';
+
 class MapSearchBar extends StatelessWidget {
   const MapSearchBar({
     Key? key,
@@ -27,13 +30,30 @@ class MapSearchBar extends StatelessWidget {
               textInputAction: TextInputAction.search,
               onChanged: (text) {},
               onSubmitted: (text) {
-                if (Provider.of<MapsDataProvider>(context, listen: false)
+                var searchText = Provider.of<MapsDataProvider>(context, listen: false)
                     .searchBarController
-                    .text
-                    .isNotEmpty) {
-                  // Don't fetch on empty text field
+                    .text;
+                if (searchText.length < 3) {
+                  print(Text("need to search more than 3"));
+                  showDialog(
+                      context: context,
+                      builder: (context) {
+                        return AlertDialogWidget(
+                          type: MessageTypeConstants.ERROR,
+                          icon: Icons.block_flipped,
+                          title: LoginConstants.mapSearchMinTitle,
+                          description: LoginConstants.mapSearchMinDesc,
+                          onClose: () {
+                            Navigator.of(context).pop();
+                          },
+                        );
+                      }
+                      );
+                  return;
+                }
+                if (searchText.isNotEmpty){
                   Provider.of<MapsDataProvider>(context, listen: false)
-                      .fetchLocations(); // Text doesn't need to be sent over because it's already in the controller
+                      .fetchLocations();
                 }
                 Navigator.pop(context);
               },

--- a/lib/ui/map/search_bar.dart
+++ b/lib/ui/map/search_bar.dart
@@ -34,7 +34,6 @@ class MapSearchBar extends StatelessWidget {
                     .searchBarController
                     .text;
                 if (searchText.length < 3) {
-                  print(Text("need to search more than 3"));
                   showDialog(
                       context: context,
                       builder: (context) {


### PR DESCRIPTION
## Summary
Users can search up less than 3 characters in the map search, which results in innacurate/many results. This change limits users so they can only search up 3 or more characters on map.

## Changelog
[General] [Add] - Add check which checks length of text that user has entered. If it's not, then show an error dialogue. 


## Test Plan
<img width="381" height="762" alt="Screenshot 2025-08-28 at 9 37 08 PM" src="https://github.com/user-attachments/assets/159098e8-dd4d-46fe-b067-1faf9be34255" />

[iOS Testing
](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B1B326846-4069-41A8-9A46-04D10BCBC505%7D&file=PR-2240-Test-Plan-7.32.0-QA-4338.xlsx&action=default&mobileredirect=true)

[Android Testing](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B7092F3CF-3F8E-4871-B42D-C151E092F4A1%7D&file=PR-2240-Test-Plan-7.32.0-QA-4339.xlsx&action=default&mobileredirect=true)

