### PR TITLE
[CAAP-429] - Refactor top.dart to be more simplified

### DIFF
--- a/lib/ui/common/top_content.dart
+++ b/lib/ui/common/top_content.dart
@@ -1,0 +1,52 @@
+import 'package:campus_mobile_experimental/app_constants.dart';
+import 'package:campus_mobile_experimental/app_styles.dart';
+import 'package:campus_mobile_experimental/core/providers/bottom_nav.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+
+class TopContent extends StatelessWidget {
+
+  TopContent({
+    this.title,
+    this.action,
+    required this.has_action,
+  });
+
+  final String? title;
+  final Widget? action;
+  final bool has_action;
+
+  @override
+  Widget build(BuildContext context) {
+    return PreferredSize
+      (preferredSize: Size.fromHeight(50),
+        child: AppBar(
+          elevation: 0,
+          backgroundColor: ColorPrimary,
+          foregroundColor: lightTextColor,
+          primary: true,
+          centerTitle: true,
+          title: Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+            child: title == null
+              ? Image.asset(
+              'assets/images/UCSanDiegoLogo-nav.png',
+                fit: BoxFit.contain,
+                height: 28,
+            )
+                : Text(
+                  title!,
+              style: appBarTitleStyle,
+            )
+          ),
+
+          actions: has_action ?
+            <Widget>[action!]
+          : <Widget>[],
+
+          systemOverlayStyle: SystemUiOverlayStyle.light,
+        ),
+    );
+  }
+}

--- a/lib/ui/common/top_content.dart
+++ b/lib/ui/common/top_content.dart
@@ -1,9 +1,6 @@
-import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_styles.dart';
-import 'package:campus_mobile_experimental/core/providers/bottom_nav.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:provider/provider.dart';
 
 class TopContent extends StatelessWidget {
 

--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -4,6 +4,7 @@ import 'package:campus_mobile_experimental/core/providers/bottom_nav.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:campus_mobile_experimental/ui/common/top_content.dart';
 
 class CMAppBar extends StatelessWidget {
   CMAppBar({
@@ -19,114 +20,53 @@ class CMAppBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (doneButton == true) {
-      return PreferredSize(
-          preferredSize: Size.fromHeight(50),
-          child: AppBar(
-              elevation: 0,
-              backgroundColor: ColorPrimary,
-              foregroundColor: lightTextColor,
-              primary: true,
-              centerTitle: true,
-              title: Padding(
-                padding: const EdgeInsets.only(bottom: 8.0),
-                child: title == null
-                    ? Image.asset(
-                        'assets/images/UCSanDiegoLogo-nav.png',
-                        fit: BoxFit.contain,
-                        height: 28,
-                      )
-                    : Text(
-                        title!,
-                        style: appBarTitleStyle,
-                      ),
+      return TopContent(
+        title: title,
+        action: Padding(
+            padding: EdgeInsets.only(bottom: 8, right: 20),
+            child: TextButton(
+              style: TextButton.styleFrom(
+                foregroundColor: darkButtonColor,
               ),
-              actions: <Widget>[
-                Padding(
-                    padding: EdgeInsets.only(bottom: 8, right: 20),
-                    child: TextButton(
-                      style: TextButton.styleFrom(
-                        foregroundColor: darkButtonColor,
-                      ),
-                      child: Text(
-                        'Done',
-                      ),
-                      onPressed: () {
-                        // Set tab bar index to the Home tab
-                        Provider.of<BottomNavigationBarProvider>(context,
-                                listen: false)
-                            .currentIndex = NavigatorConstants.HomeTab;
-
-                        // Navigate to Home tab
-                        Navigator.of(context).pushNamedAndRemoveUntil(
-                            RoutePaths.BottomNavigationBar,
-                            (Route<dynamic> route) => false);
-
-                        // change the appBar title to the ucsd logo
-                        Provider.of<CustomAppBar>(context, listen: false)
-                            .changeTitle(CustomAppBar().appBar.title);
-                      },
-                    ))
-              ],
-              systemOverlayStyle: SystemUiOverlayStyle.light));
+              child: Text(
+                'Done',
+              ),
+              onPressed: () {
+                // Set tab bar index to the Home tab
+                Provider.of<BottomNavigationBarProvider>(context,
+                    listen: false)
+                    .currentIndex = NavigatorConstants.HomeTab;
+                // Navigate to Home tab
+                Navigator.of(context).pushNamedAndRemoveUntil(
+                    RoutePaths.BottomNavigationBar,
+                        (Route<dynamic> route) => false);
+                // change the appBar title to the ucsd logo
+                Provider.of<CustomAppBar>(context, listen: false)
+                    .changeTitle(CustomAppBar().appBar.title);
+              },
+            )),
+          has_action: true,
+      );
     } else if (notificationsFilterButton == true) {
-      return PreferredSize(
-          preferredSize: Size.fromHeight(50),
-          child: AppBar(
-              elevation: 0,
-              backgroundColor: ColorPrimary,
-              foregroundColor: lightTextColor,
-              primary: true,
-              centerTitle: true,
-              title: Padding(
-                padding: const EdgeInsets.only(bottom: 8.0),
-                child: title == null
-                    ? Image.asset(
-                        'assets/images/UCSanDiegoLogo-nav.png',
-                        fit: BoxFit.contain,
-                        height: 28,
-                      )
-                    : Text(
-                        title!,
-                        style: appBarTitleStyle,
-                      ),
-              ),
-              actions: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 8.0),
-                  child: IconButton(
-                    icon: Icon(Icons.filter_list_outlined),
-                    onPressed: () {
-                      Navigator.pushNamed(
-                          context, RoutePaths.NotificationsFilter);
-                    },
-                  ),
-                )
-              ],
-              systemOverlayStyle: SystemUiOverlayStyle.light));
-    } else {
-      return PreferredSize(
-        preferredSize: Size.fromHeight(50),
-        child: AppBar(
-          elevation: 0,
-          backgroundColor: ColorPrimary,
-          foregroundColor: lightTextColor,
-          primary: true,
-          centerTitle: true,
-          title: Padding(
-            padding: const EdgeInsets.only(bottom: 8.0),
-            child: title == null
-                ? Image.asset(
-                    'assets/images/UCSanDiegoLogo-nav.png',
-                    fit: BoxFit.contain,
-                    height: 28,
-                  )
-                : Text(
-                    title!,
-                    style: appBarTitleStyle,
-                  ),
+      return TopContent(
+        title: title,
+        action: Padding(
+          padding: const EdgeInsets.only(bottom: 8.0),
+          child: IconButton(
+            icon: Icon(Icons.filter_list_outlined),
+            onPressed: () {
+              Navigator.pushNamed(
+                  context, RoutePaths.NotificationsFilter);
+            },
           ),
-          systemOverlayStyle: SystemUiOverlayStyle.light,
         ),
+        has_action: true,
+      );
+    } else {
+      return TopContent(
+        title: title,
+        action: null,
+        has_action: false,
       );
     }
   }

--- a/lib/ui/navigator/top.dart
+++ b/lib/ui/navigator/top.dart
@@ -2,7 +2,6 @@ import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:campus_mobile_experimental/core/providers/bottom_nav.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:campus_mobile_experimental/ui/common/top_content.dart';
 
@@ -95,12 +94,6 @@ class CustomAppBar extends ChangeNotifier {
     title = RouteTitles.titleMap[newTitle];
     doneButton = done;
     notificationsFilterButton = notification;
-
-    // if (newTitle == "Notifications") {
-    //   notificationsFilterButton = true;
-    // } else {
-    //   notificationsFilterButton = false;
-    // }
 
     makeAppBar();
   }


### PR DESCRIPTION
## Summary
Currently top.dart has 3 PreferredSize widgets, with a lot of repeated code. 

## Changelog
[General] [Change] - I made a new top_content.dart widget in the common folder to be reused in top.dart, and passed parameters (title, has_action, action)


## Test Plan
[iOS Testing](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7BB599CABA-B095-4450-B13A-1C2180655DC3%7D&file=PR-2241-Test-Plan-7.32.0-QA-4346.xlsx&action=default&mobileredirect=true)

[Android Testing](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7BDAE7E62F-E909-4EF0-8170-34FFAC741D00%7D&file=PR-2241-Test-Plan-7.32.0-QA-4347.xlsx&action=default&mobileredirect=true)

