### PR TITLE
[CAAP-462] - Error Rendering ID Card

### DIFF
--- a/lib/core/models/student_id_profile.dart
+++ b/lib/core/models/student_id_profile.dart
@@ -41,7 +41,7 @@ class StudentIdProfileModel {
       StudentIdProfileModel(
         studentPid: json["Student_PID"],
         termYear: json["Term_Year"],
-        studentLevelCurrent: json["Student_Level_Current"],
+        studentLevelCurrent: json["Student_Level_Current"] == null ? "" : json["Student_Level_Current"],
         collegeCurrent:
             json["College_Current"] == null ? "" : json["College_Current"],
         ugPrimaryMajorCurrent: json["UG_Primary_Major_Current"] == null


### PR DESCRIPTION
## Summary
Student ID card was not rendering for incoming students.


## Changelog
[General] [Fix] - Added a null check if student's current year was null, so the UI would still render correctly. 


## Test Plan


