### PR TITLE
[CAAPP-464] fix: parking card new spot types exception

### DIFF
--- a/lib/core/providers/parking.dart
+++ b/lib/core/providers/parking.dart
@@ -98,7 +98,7 @@ class ParkingDataProvider extends ChangeNotifier {
       Map<String, bool> newMapOfSpotTypes = Map<String, bool>();
       for (Spot spot in _spotTypeModel.spots!) {
         newMapOfSpotTypes[spot.spotKey] =
-            _selectedSpotTypesState[spot.spotKey]!;
+            _selectedSpotTypesState[spot.spotKey] ?? false;
       }
       _selectedSpotTypesState = newMapOfSpotTypes;
 


### PR DESCRIPTION
## Summary
Parking card not loading when logged in.

```I/flutter (31996): Null check operator used on a null valueI/flutter (31996): #0      ParkingDataProvider.fetchParkingData (package:campus_mobile_experimental/core/providers/parking.dart:101:50)I/flutter (31996): <asynchronous suspension> ```

Notes:
- Reproduced on QA experimental branch.
  - Requires an existing user profile from 7.31 or older.
- Not reproducible on 7.31 PROD.
- Caused by logic around parking spot type preference sync from remote user profile.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Fix parking card spot types exception related to remote user profile sync


## Test Plan
Parking card works as expected when logged out
Parking card works as expected when logged in
Parking card works as expected when logged in with an existing user profile from <=7.31
