### PR TITLE
[BTSRMPSE-744] Re-enablesouth/scholars to parking lots

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -73,6 +73,8 @@ class ParkingDefaults {
     "Gilman",
     "Hopkins",
     "Theatre District",
+    "South",
+    "Scholars",
   ];
   static const defaultSpots = ["S", "B", "A"];
 }


### PR DESCRIPTION
## Summary
Current app doesn't include South and Scholars parking structures. 

## Changelog
[General] [Add] - Added "South" and "Scholars" to parking lot constants so they show up by default in the app. 