### PR TITLE
[CAAP-423] Upgraded pointycastle and encrypt

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -285,10 +285,10 @@ packages:
     dependency: "direct main"
     description:
       name: encrypt
-      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -757,26 +757,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   linkify:
     dependency: transitive
     description:
@@ -1021,10 +1021,10 @@ packages:
     dependency: "direct main"
     description:
       name: pointycastle
-      sha256: d0d95ef66e5327394d2dab33cbcb2cde3a9fb275abe75ebfedd0f54392878df7
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
@@ -1218,10 +1218,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   timezone:
     dependency: transitive
     description:
@@ -1330,10 +1330,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   barcode_widget: 2.0.4
   connectivity_plus: 6.1.0
   dio: ^5.9.0
-  encrypt: 5.0.1
+  encrypt: ^5.0.3
   dots_indicator: 4.0.1
   firebase_analytics: 11.3.3
   firebase_core: 3.6.0
@@ -35,7 +35,7 @@ dependencies:
   package_info_plus: ^8.3.1
   percent_indicator: 4.2.3
   permission_handler: ^12.0.1
-  pointycastle: 3.4.0
+  pointycastle: ^3.9.0
   provider: ^6.1.5+1
   shared_preferences: ^2.5.3
   app_links: ^3.0.0


### PR DESCRIPTION
## Changelog
[General][Upgrade] - upgraded pointycastle from  3.4.0 to ^3.9.0 and encrypt from 5.0.1 to ^5.0.3. I upgraded pointy castle with encrypt as encrypt required a higher version of pointy castle. 


## Test Plan
Seeing that pointycastle and encrypt is used for login, test login/logout, and silent login. 

- iOS: [PR-2271 Test Plan (iOS)](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7BD1216039-9456-4567-9A92-1975F534A7E9%7D&file=PR-2271-Test-Plan-7.34.0-QA-4845.xlsx&action=default&mobileredirect=true)
- Android: [PR-2271 Test Plan (Android)](https://ucsdcloud.sharepoint.com/:x:/r/sites/WorkplaceTechnologyServices-CampusMobileBuilds/_layouts/15/Doc.aspx?sourcedoc=%7B2569931D-E796-4F0C-BE94-2F0A1753626B%7D&file=PR-2271-Test-Plan-7.34.0-QA-4846.xlsx&action=default&mobileredirect=true)


