### PR TITLE
(CAAPP-490) Shuttle Stop Icon [Fix]

### DIFF
--- a/lib/ui/shuttle/shuttle_display.dart
+++ b/lib/ui/shuttle/shuttle_display.dart
@@ -197,6 +197,10 @@ class ShuttleDisplay extends StatelessWidget {
 
   Widget buildArrivalTime(BuildContext context, ArrivingShuttle shuttle) {
     var minutesToArrival = shuttle.secondsToArrival ~/ 60;
+    // Calculate luminance to determine the color of the text
+    Color circleColor = HexColor(shuttle.routeColor);
+    final double luminance = circleColor.computeLuminance();
+    final Color textColor = luminance > 0.5 ? Colors.black : Colors.white;
     return Row(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
@@ -204,8 +208,8 @@ class ShuttleDisplay extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(16.0, 8.0, 8.0, 8.0),
           child: CircleAvatar(
             minRadius: 20,
-            backgroundColor: HexColor(shuttle.routeColor),
-            foregroundColor: Colors.black,
+            backgroundColor: circleColor,
+            foregroundColor: textColor,
             child: Text(
               shuttle.routeName[0],
               style: TextStyle(fontSize: 25),


### PR DESCRIPTION
## Summary
[[CAAPP-490](https://its-pro.ucsd.edu/browse/CAAPP-490)] The app had a shuttle logo with a dark circle and dark text. 
<img width="689" height="175" alt="image" src="https://github.com/user-attachments/assets/adf6cb87-f498-4b21-a35f-a229a905e284" />

It has now been changed to a dark circle and white text (based on circle's luminance as implemented in the main upcoming arrival information).


## Changelog
[General] [Fix] - Fixed the dark text on dark circle problem.


## Test Plan
Ensure the Shuttle card doesn't show a dark circle with a dark text.

