### PR TITLE
[BTSRMPSE-744 and MA-515] Added first ave and south as default parking lots 

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -68,12 +68,7 @@ class RouteTitles {
 }
 
 class ParkingDefaults {
-  static const DEFAULT_LOTS = [
-    "Athena",
-    "Gilman",
-    "Hopkins",
-    "Theatre District",
-  ];
+  static const DEFAULT_LOTS = ["Athena", "Gilman", "Hopkins", "Theatre District", "South", "Scholars", "First Ave"];
   static const DEFAULT_SPOTS = ["S", "B", "A"];
 }
 

--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -68,7 +68,7 @@ class RouteTitles {
 }
 
 class ParkingDefaults {
-  static const DEFAULT_LOTS = ["Athena", "Gilman", "Hopkins", "Theatre District", "South", "Scholars", "First Ave"];
+  static const DEFAULT_LOTS = ["Athena", "Gilman", "Hopkins", "Theatre District", "South", "First Ave"];
   static const DEFAULT_SPOTS = ["S", "B", "A"];
 }
 


### PR DESCRIPTION
## Summary
The app doesn't show First Ave or South as default parking lots by default, unlike the other parking lots. Users have to manually toggle them on. 

## Changelog
[General] [Add] - Added First Ave and South as constants so they show up as the default parking lots. 


## Test Plan
Ensure First Ave and South  show up by default. 
