### PR TITLE
Change card background colors to red

### DIFF
--- a/lib/app_styles.dart
+++ b/lib/app_styles.dart
@@ -21,7 +21,7 @@ style: Theme.of(context).brightness == Brightness.dark
 const Color lightPrimaryColor = Color(0xFF182B49);
 const Color darkPrimaryColor = Color(0xFF333333);
 const Color darkPrimaryColor2 = Color(0xFFF5F0E6);
-const Color darkPrimaryBgColor = Color(0xff1D1D1D);
+const Color darkPrimaryBgColor = Color(0xFFFF0000);
 
 const Color secondaryColorLight = Color(0xFF182B49);
 const Color secondaryColorDark = Color(0xFF5496BC);
@@ -308,7 +308,7 @@ const Color bottomTabBarColorDark = Color(0xFF404142);
 const Color lightTextFieldBorderColor = Color(0xFFFFFFFF);
 
 // Accent colors for themes
-const Color lightAccentColor = Color(0xFFFFFFFF);
+const Color lightAccentColor = Color(0xFFFF0000);
 const Color darkAccentColor = Color(0xFF333333);
 
 // Universal color for themes


### PR DESCRIPTION
## Summary
This PR changes the card background colors from their default colors to red for both light and dark modes.

## Changelog
[General] [Change] - Changed card background colors to red (#FF0000) in both light and dark themes

## Test Plan
1. Updated lightAccentColor from #FFFFFF (white) to #FF0000 (red) for light mode card backgrounds
2. Updated darkPrimaryBgColor from #1D1D1D (dark gray) to #FF0000 (red) for dark mode card backgrounds
3. Verified changes in app_styles.dart
4. Ran flutter analyze to ensure no new errors were introduced