### PR TITLE
[MA-583] Busyness Card Refresh Bug Fix

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         applicationId = "edu.ucsd"
-        minSdkVersion = 23
+        minSdkVersion = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         applicationId = "edu.ucsd"
-        minSdkVersion = flutter.minSdkVersion
+        minSdkVersion = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/lib/core/models/availability.dart
+++ b/lib/core/models/availability.dart
@@ -26,7 +26,8 @@ class AvailabilityStatus {
               List<AvailabilityModel>.from(json["data"]!.map((x) => AvailabilityModel.fromJson(x)));
 
           // TODO: remove this line after the missing Markets data is fixed on the backend - December 2025
-          returnList.removeWhere((model) => model.name == "Markets");
+          // disable after json on cms is updated with correct endpoint name
+          // returnList.removeWhere((model) => model.name == "Markets");
 
           for (int index = 0; index < returnList.length; index++) {
             if (returnList[index].subLocations.length > 3) {

--- a/lib/core/providers/availability.dart
+++ b/lib/core/providers/availability.dart
@@ -28,6 +28,8 @@ class AvailabilityDataProvider extends ChangeNotifier {
     Map<String, AvailabilityModel> newMapOfLots = {};
 
     if (await _availabilityService.fetchData()) {
+      Map<String?, bool> newLocationViewState = {};
+
       /// setting the LocationViewState based on user data
       for (AvailabilityModel model in _availabilityService.data) {
         String curName = model.name;
@@ -37,15 +39,20 @@ class AvailabilityDataProvider extends ChangeNotifier {
 
         /// if the user is logged out and has not put any preferences,
         /// show all locations by default
-        final bool hasNoSelectedLocations = userDataProvider.userProfileModel.selectedOccuspaceLocations!.isEmpty;
+        final selectedLocations = userDataProvider.userProfileModel.selectedOccuspaceLocations ?? [];
+        final bool hasNoSelectedLocations = selectedLocations.isEmpty;
+        
         if (hasNoSelectedLocations)
-          _locationViewState[curName] = true;
-
-        /// otherwise, LocationViewState should be true for all selectedOccuspaceLocations
+          newLocationViewState[curName] = _locationViewState[curName] ?? true;
         else {
-          _locationViewState[curName] = userDataProvider.userProfileModel.selectedOccuspaceLocations!.contains(curName);
+          newLocationViewState[curName] = _locationViewState[curName] ??
+              userDataProvider.userProfileModel.selectedOccuspaceLocations!.contains(curName);
         }
       }
+
+      // After the loop, assign it:
+      _locationViewState = newLocationViewState;
+    
 
       /// replace old list of lots with new one
       _availabilityModels = newMapOfLots;

--- a/lib/ui/availability/availability_card.dart
+++ b/lib/ui/availability/availability_card.dart
@@ -41,7 +41,10 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
         setState(() {
           _currentPage = 0;
         });
-        _controller.animateToPage(0, duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+        // check at least one is enabled to avoid crash
+        if (_controller.hasClients) {
+          _controller.animateToPage(0, duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+        }
         _availabilityDataProvider.fetchAvailability();
       },
       isLoading: _availabilityDataProvider.isLoading,
@@ -65,7 +68,7 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
         String curName = model.name;
         RegExpMatch? match = multiPager.firstMatch(curName);
         if (match != null) curName = curName.replaceRange(match.start, match.end, '');
-        final bool shouldShowLocation = _availabilityDataProvider.locationViewState[curName]!;
+        final bool shouldShowLocation = _availabilityDataProvider.locationViewState[curName] ?? false;
         if (shouldShowLocation) locationsList.add(AvailabilityDisplay(model: model));
       }
     }
@@ -118,7 +121,7 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
             child: Container(
               margin: const EdgeInsets.only(top: 30.0),
               child: DotsIndicator(
-                position: _currentPage.toDouble(),
+                position: _currentPage.clamp(0, locationsList.length - 1).toDouble(),
                 dotsCount: locationsList.length,
                 decorator: DotsDecorator(
                   color: dotsUnselectedColor,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -765,26 +765,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   linkify:
     dependency: transitive
     description:
@@ -813,18 +813,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   measured_size:
     dependency: "direct main"
     description:
@@ -837,10 +837,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1226,10 +1226,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.9"
   timezone:
     dependency: transitive
     description:
@@ -1338,10 +1338,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1464,5 +1464,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.32.0"


### PR DESCRIPTION
## Summary
Dining halls category on the busyness card keeps being untoggled upon refresh.

- Preserves the location view state across availability refreshes, even when ⁠selectedOccuspaceLocations is null or empty. 
- Prevents crashes in the availability pager when no locations are visible or when the page controller has no clients.
- Re‑enables Markets by no longer filtering it out (temporary disable removed).


## Changelog
[General] [Fix] - Preserve busyness card location selection across refresh and prevent crashes when no locations are visible



## Test Plan
1. Dining halls stay selected across refresh
  - Without logging in, add busyness location categories, then refresh the card
    - all selected cards should persist
  - Log in with a user and add busyness location categories
    - refresh should maintain all active categories
    - closing and reopening app should maintain all active categories

2. No selected locations
  - Untoggle all categories the busyness card. 
  - Check card to ensure expected behavior
  - Refresh the card and should still keep no cards

3. Locations data availability
  - With updated JSON, should see the following locations (check names as they are now using an alias)
    - Libraries: Geisel, Wong Avery
    - Price Center
    - Recreational Facilities: RIMAC Gym, Main Gym, Triton Esports Center, Outdoor Climbing Center
    - Dining Halls: OceanView, Pines, 64 Degrees, Ventanas, Canyon Vista Marketplace, Club Med, Restaurants at Sixth College
    - Markets: Roger's Market, Seventh Market, Sixth Market