### PR TITLE
[MA-583] Busyness Card Refresh Bug Fix

### DIFF
--- a/lib/core/models/availability.dart
+++ b/lib/core/models/availability.dart
@@ -26,7 +26,8 @@ class AvailabilityStatus {
               List<AvailabilityModel>.from(json["data"]!.map((x) => AvailabilityModel.fromJson(x)));
 
           // TODO: remove this line after the missing Markets data is fixed on the backend - December 2025
-          returnList.removeWhere((model) => model.name == "Markets");
+          // disable after json on cms is updated with correct endpoint name
+          // returnList.removeWhere((model) => model.name == "Markets");
 
           for (int index = 0; index < returnList.length; index++) {
             if (returnList[index].subLocations.length > 3) {

--- a/lib/core/providers/availability.dart
+++ b/lib/core/providers/availability.dart
@@ -28,6 +28,8 @@ class AvailabilityDataProvider extends ChangeNotifier {
     Map<String, AvailabilityModel> newMapOfLots = {};
 
     if (await _availabilityService.fetchData()) {
+      Map<String?, bool> newLocationViewState = {};
+
       /// setting the LocationViewState based on user data
       for (AvailabilityModel model in _availabilityService.data) {
         String curName = model.name;
@@ -37,15 +39,20 @@ class AvailabilityDataProvider extends ChangeNotifier {
 
         /// if the user is logged out and has not put any preferences,
         /// show all locations by default
-        final bool hasNoSelectedLocations = userDataProvider.userProfileModel.selectedOccuspaceLocations!.isEmpty;
+        final selectedLocations = userDataProvider.userProfileModel.selectedOccuspaceLocations ?? [];
+        final bool hasNoSelectedLocations = selectedLocations.isEmpty;
+        
         if (hasNoSelectedLocations)
-          _locationViewState[curName] = true;
-
-        /// otherwise, LocationViewState should be true for all selectedOccuspaceLocations
+          newLocationViewState[curName] = _locationViewState[curName] ?? true;
         else {
-          _locationViewState[curName] = userDataProvider.userProfileModel.selectedOccuspaceLocations!.contains(curName);
+          newLocationViewState[curName] = _locationViewState[curName] ??
+              userDataProvider.userProfileModel.selectedOccuspaceLocations!.contains(curName);
         }
       }
+
+      // After the loop, assign it:
+      _locationViewState = newLocationViewState;
+    
 
       /// replace old list of lots with new one
       _availabilityModels = newMapOfLots;

--- a/lib/ui/availability/availability_card.dart
+++ b/lib/ui/availability/availability_card.dart
@@ -41,7 +41,10 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
         setState(() {
           _currentPage = 0;
         });
-        _controller.animateToPage(0, duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+        // check at least one is enabled to avoid crash
+        if (_controller.hasClients) {
+          _controller.animateToPage(0, duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+        }
         _availabilityDataProvider.fetchAvailability();
       },
       isLoading: _availabilityDataProvider.isLoading,
@@ -65,7 +68,7 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
         String curName = model.name;
         RegExpMatch? match = multiPager.firstMatch(curName);
         if (match != null) curName = curName.replaceRange(match.start, match.end, '');
-        final bool shouldShowLocation = _availabilityDataProvider.locationViewState[curName]!;
+        final bool shouldShowLocation = _availabilityDataProvider.locationViewState[curName] ?? false;
         if (shouldShowLocation) locationsList.add(AvailabilityDisplay(model: model));
       }
     }
@@ -118,7 +121,7 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
             child: Container(
               margin: const EdgeInsets.only(top: 30.0),
               child: DotsIndicator(
-                position: _currentPage.toDouble(),
+                position: _currentPage.clamp(0, locationsList.length - 1).toDouble(),
                 dotsCount: locationsList.length,
                 decorator: DotsDecorator(
                   color: dotsUnselectedColor,


### PR DESCRIPTION
## Summary
Dining halls category on the busyness card keeps being untoggled upon refresh.

- Preserves the location view state across availability refreshes, even when ⁠selectedOccuspaceLocations is null or empty. 
- Prevents crashes in the availability pager when no locations are visible or when the page controller has no clients.
- Re‑enables Markets by no longer filtering it out (temporary disable removed).


## Changelog
[General] [Fix] - Preserve busyness card location selection across refresh and prevent crashes when no locations are visible



## Test Plan
1. Dining halls stay selected across refresh
  - Without logging in, add busyness location categories, then refresh the card
    - all selected cards should persist
  - Log in with a user and add busyness location categories
    - refresh should maintain all active categories
    - closing and reopening app should maintain all active categories

2. No selected locations
  - Untoggle all categories the busyness card. 
  - Check card to ensure expected behavior
  - Refresh the card and should still keep no cards

3. Locations data availability
  - With updated JSON, should see the following locations (check names as they are now using an alias)
    - Libraries: Geisel, Wong Avery
    - Price Center
    - Recreational Facilities: RIMAC Gym, Main Gym, Triton Esports Center, Outdoor Climbing Center
    - Dining Halls: OceanView, Pines, 64 Degrees, Ventanas, Canyon Vista Marketplace, Club Med, Restaurants at Sixth College
    - Markets: Roger's Market, Seventh Market, Sixth Market