### PR TITLE
Hive registration and App Wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ build/
 
 # Generated dart files
 *.g.dart
+# TGPT Hive adapter (tracked for CI without build_runner in pre-test)
+!lib/core/models/tgpt_models/chat_message_persistent.g.dart
 *.freezed.dart
 *.mocks.dart
 *.config.dart

--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -139,7 +139,8 @@ class NavigatorConstants {
   static const HOME_TAB = 0;
   static const MAP_TAB = 1;
   static const NOTIFICATIONS_TAB = 2;
-  static const PROFILE_TAB = 3;
+  static const CHAT_TAB = 3;
+  static const PROFILE_TAB = 4;
 }
 
 class NotificationsConstants {

--- a/lib/core/models/tgpt_models/chat_message_persistent.g.dart
+++ b/lib/core/models/tgpt_models/chat_message_persistent.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_message_persistent.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class ChatMessagePersistentAdapter extends TypeAdapter<ChatMessagePersistent> {
+  @override
+  final int typeId = 3;
+
+  @override
+  ChatMessagePersistent read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ChatMessagePersistent(
+      id: fields[0] as String,
+      text: fields[1] as String,
+      authorId: fields[2] as String,
+      createdAt: fields[3] as int,
+      isFromUser: fields[4] as bool,
+      sessionId: fields[5] as String?,
+      parentMessageId: fields[6] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ChatMessagePersistent obj) {
+    writer
+      ..writeByte(7)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.text)
+      ..writeByte(2)
+      ..write(obj.authorId)
+      ..writeByte(3)
+      ..write(obj.createdAt)
+      ..writeByte(4)
+      ..write(obj.isFromUser)
+      ..writeByte(5)
+      ..write(obj.sessionId)
+      ..writeByte(6)
+      ..write(obj.parentMessageId);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ChatMessagePersistentAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/core/providers/user.dart
+++ b/lib/core/providers/user.dart
@@ -6,6 +6,7 @@ import 'package:campus_mobile_experimental/core/models/user_profile.dart';
 import 'package:campus_mobile_experimental/core/providers/cards.dart';
 import 'package:campus_mobile_experimental/core/providers/notifications.dart';
 import 'package:campus_mobile_experimental/core/services/authentication.dart';
+import 'package:campus_mobile_experimental/core/services/tgpt_services/chat_persistence.dart';
 import 'package:campus_mobile_experimental/core/services/user.dart';
 import 'package:campus_mobile_experimental/ui/navigator/bottom.dart';
 import 'package:encrypt/encrypt.dart';
@@ -37,6 +38,7 @@ class UserDataProvider extends ChangeNotifier {
   /// SERVICES
   var _authenticationService = AuthenticationService();
   var _userProfileService = UserProfileService();
+  late final ChatPersistenceService _chatPersistenceService = ChatPersistenceService(this);
   // var storage = FlutterSecureStorage();
   final storage = const FlutterSecureStorage(
     iOptions: IOSOptions(
@@ -265,6 +267,7 @@ class UserDataProvider extends ChangeNotifier {
     resetAllCardHeights();
     resetNotificationsScrollOffset();
     _pushNotificationDataProvider.unregisterDevice(_authenticationModel.accessToken);
+    await _chatPersistenceService.clearUserChatData();
     updateAuthenticationModel(AuthenticationModel.fromJson({}));
     updateUserProfileModel(await _createNewUser(UserProfileModel.fromJson({})));
     _deletePasswordFromDevice();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:campus_mobile_experimental/app_provider.dart';
 import 'package:campus_mobile_experimental/app_router.dart' as campusMobileRouter;
 import 'package:campus_mobile_experimental/app_styles.dart';
 import 'package:campus_mobile_experimental/core/models/authentication.dart';
+import 'package:campus_mobile_experimental/core/models/tgpt_models/chat_message_persistent.dart';
 import 'package:campus_mobile_experimental/core/models/user_profile.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
@@ -52,6 +53,7 @@ Future<void> initializeHive() async {
   await Hive.initFlutter('.');
   Hive.registerAdapter(AuthenticationModelAdapter());
   Hive.registerAdapter(UserProfileModelAdapter());
+  Hive.registerAdapter(ChatMessagePersistentAdapter());
 }
 
 Future<void> initializeApp() async {

--- a/lib/ui/navigator/bottom.dart
+++ b/lib/ui/navigator/bottom.dart
@@ -32,6 +32,7 @@ class _BottomTabBarState extends State<BottomTabBar> {
     Home(),
     prefix0.Maps(),
     NotificationsListView(),
+    Container(),
     Profile(),
   ];
 
@@ -76,6 +77,10 @@ class _BottomTabBarState extends State<BottomTabBar> {
                 Provider.of<CustomAppBar>(context, listen: false)
                     .changeTitle("Notifications", done: false, notification: true);
                 break;
+              case NavigatorConstants.CHAT_TAB:
+                resetAllCardLoadedStates();
+                Provider.of<CustomAppBar>(context, listen: false).changeTitle("Chat");
+                break;
               case NavigatorConstants.PROFILE_TAB:
                 resetAllCardLoadedStates();
                 Provider.of<CustomAppBar>(context, listen: false).changeTitle("Profile");
@@ -96,7 +101,11 @@ class _BottomTabBarState extends State<BottomTabBar> {
               label: 'NOTIFICATIONS',
             ),
             BottomNavigationBarItem(
-              icon: _buildIcon(Icons.person, provider.currentIndex == 3, theme, size: 38),
+              icon: _buildIcon(Icons.chat_bubble_outline, provider.currentIndex == 3, theme),
+              label: 'CHAT',
+            ),
+            BottomNavigationBarItem(
+              icon: _buildIcon(Icons.person, provider.currentIndex == 4, theme, size: 38),
               label: 'PROFILE',
             ),
           ],

--- a/lib/ui/wifi/wifi_card.dart
+++ b/lib/ui/wifi/wifi_card.dart
@@ -110,15 +110,16 @@ class _WiFiCardState extends State<WiFiCard> with AutomaticKeepAliveClientMixin 
     // STATE MACHINE
     return Padding(
       padding: const EdgeInsets.only(left: 8, right: 8, top: 8),
-      child: switch (cardState) {
-        TestStatus.initial => initialState(context),
-        TestStatus.running => speedTest(),
-        TestStatus.finished => finishedState(),
-        TestStatus.unavailable => unavailableState(),
-        TestStatus.simulated => simulatedState(),
-        _ => initialState(context) // Default State (Initial)
-      },
+      child: _buildStateWidget(context),
     );
+  }
+
+  Widget _buildStateWidget(BuildContext context) {
+    if (cardState == TestStatus.running) return speedTest();
+    if (cardState == TestStatus.finished) return finishedState();
+    if (cardState == TestStatus.unavailable) return unavailableState();
+    if (cardState == TestStatus.simulated) return simulatedState();
+    return initialState(context);
   }
 
   //////////// INITIAL STATE (Before Testing for the first time) ////////////


### PR DESCRIPTION
 Set up the infrastructure needed for ChatPersistenceService.

  Changes:
  - main.dart — registers ChatMessagePersistentAdapter in initializeHive() so Hive can read/write
  ChatMessagePersistent objects
  - app_constants.dart — adds CHAT_TAB = 3 to NavigatorConstants and shifts PROFILE_TAB to 4
  - bottom.dart — adds Chat as the fourth tab (index 3) with a placeholder view; updates switch cases and icon
  selection highlights to match new indices
  - user.dart — calls ChatPersistenceService.clearUserChatData() during logout(), before the auth model is wiped,
  so chat history is cleared on logout
  - wifi_card.dart — replaces Dart 3 switch expression with a helper method (_buildStateWidget) to fix a
  hive_generator parse failure that was blocking build_runner