### PR TITLE
MA 608 Add Accessibility Pt 1

### DIFF
--- a/lib/ui/availability/availability_display.dart
+++ b/lib/ui/availability/availability_display.dart
@@ -98,10 +98,14 @@ class AvailabilityDisplay extends StatelessWidget {
                     Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(
-                          Icons.arrow_forward_ios,
-                          size: 35,
-                          color: Theme.of(context).brightness == Brightness.dark ? linkColorLight : linkColorDark,
+                        Semantics(
+                          label: 'View details for ${subLocation.name}',
+                          button: true,
+                          child: Icon(
+                            Icons.arrow_forward_ios,
+                            size: 35,
+                            color: Theme.of(context).brightness == Brightness.dark ? linkColorLight : linkColorDark,
+                          ),
                         ),
                       ],
                     ),

--- a/lib/ui/availability/availability_display.dart
+++ b/lib/ui/availability/availability_display.dart
@@ -26,11 +26,15 @@ class AvailabilityDisplay extends StatelessWidget {
     return Container(
       alignment: Alignment.centerLeft,
       margin: EdgeInsets.only(bottom: 8),
-      child: Text(
-        model.name.toUpperCase(),
-        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.normal,
-            ),
+      child: Semantics(
+        label: '${model.name.toUpperCase()}. Swipe left or right to view other areas',
+        excludeSemantics: true,
+        child: Text(
+          model.name.toUpperCase(),
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.normal,
+              ),
+        ),
       ),
     );
   }

--- a/lib/ui/availability/availability_display.dart
+++ b/lib/ui/availability/availability_display.dart
@@ -57,7 +57,7 @@ class AvailabilityDisplay extends StatelessWidget {
         child: Semantics(
           button: subLocation.floors.isNotEmpty,
           label: subLocation.floors.isNotEmpty
-              ? 'View details for ${subLocation.name}. ${(100 * percentAvailability(subLocation)).toInt()}% Busy'
+              ? '${subLocation.name}. ${(100 * percentAvailability(subLocation)).toInt()}% Busy. View details for ${subLocation.name}'
               : '${subLocation.name}. ${(100 * percentAvailability(subLocation)).toInt()}% Busy',
           excludeSemantics: true,
           child: GestureDetector(

--- a/lib/ui/availability/availability_display.dart
+++ b/lib/ui/availability/availability_display.dart
@@ -54,7 +54,13 @@ class AvailabilityDisplay extends StatelessWidget {
     List<Widget> locations = model.subLocations.map((subLocation) {
       return Padding(
         padding: EdgeInsets.symmetric(vertical: 10),
-        child: GestureDetector(
+        child: Semantics(
+          button: subLocation.floors.isNotEmpty,
+          label: subLocation.floors.isNotEmpty
+              ? 'View details for ${subLocation.name}. ${(100 * percentAvailability(subLocation)).toInt()}% Busy'
+              : '${subLocation.name}. ${(100 * percentAvailability(subLocation)).toInt()}% Busy',
+          excludeSemantics: true,
+          child: GestureDetector(
           onTap: () {
             if (subLocation.floors.isNotEmpty) {
               Navigator.pushNamed(
@@ -98,14 +104,10 @@ class AvailabilityDisplay extends StatelessWidget {
                     Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Semantics(
-                          label: 'View details for ${subLocation.name}',
-                          button: true,
-                          child: Icon(
-                            Icons.arrow_forward_ios,
-                            size: 35,
-                            color: Theme.of(context).brightness == Brightness.dark ? linkColorLight : linkColorDark,
-                          ),
+                        Icon(
+                          Icons.arrow_forward_ios,
+                          size: 35,
+                          color: Theme.of(context).brightness == Brightness.dark ? linkColorLight : linkColorDark,
                         ),
                       ],
                     ),
@@ -128,6 +130,7 @@ class AvailabilityDisplay extends StatelessWidget {
               ),
             ],
           ),
+        ),
         ),
       );
     }).toList();

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -218,7 +218,12 @@ class DiningList extends StatelessWidget {
 
   // Builds the Right side of the ListTile containing the icon and distance
   Widget buildIconWithDistance(dining_model.DiningModel data, BuildContext context) {
-    return TextButton(
+    String distanceText = data.distance != null ? '${num.parse(data.distance!.toStringAsFixed(1))} miles' : '';
+    return Semantics(
+      label: distanceText,
+      button: true,
+      excludeSemantics: true,
+      child: TextButton(
       style: TextButton.styleFrom(
         foregroundColor: linkColorLight,
       ),
@@ -241,6 +246,7 @@ class DiningList extends StatelessWidget {
           ),
         ],
       ),
+    ),
     );
   }
 }

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -211,7 +211,6 @@ class DiningList extends StatelessWidget {
         Navigator.pushNamed(context, RoutePaths.DINING_OPTION_DETAIL_VIEW, arguments: data);
       },
     ),
-    ),
     );
   }
 

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -165,11 +165,10 @@ class DiningList extends StatelessWidget {
   }
 
   Widget buildDiningTile(dining_model.DiningModel data, BuildContext context) {
-    return MergeSemantics(
-      child: Semantics(
-        link: true,
-        label: 'Open link',
-        child: ListTile(
+    return Semantics(
+      link: true,
+      hint: 'Open link',
+      child: ListTile(
       contentPadding: EdgeInsets.zero,
       // Vendor Logo
       minLeadingWidth: 0, // Reduce minimum width

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -164,10 +164,34 @@ class DiningList extends StatelessWidget {
     );
   }
 
+  String _getHoursTextForToday(dining_model.RegularHours hours) {
+    int weekday = DateTime.now().weekday;
+    String? dayHours;
+    switch (weekday) {
+      case 1: dayHours = hours.mon; break;
+      case 2: dayHours = hours.tue; break;
+      case 3: dayHours = hours.wed; break;
+      case 4: dayHours = hours.thu; break;
+      case 5: dayHours = hours.fri; break;
+      case 6: dayHours = hours.sat; break;
+      case 7: dayHours = hours.sun; break;
+    }
+    if (dayHours == null || dayHours == 'Closed-Closed') {
+      String text = 'Closed';
+      String? nextDay = findNextOpenDay(hours);
+      String? nextTime = findNextOpenTime(hours);
+      if (nextDay != null && nextTime != null) text += '. Opens $nextDay at $nextTime';
+      return text;
+    }
+    if (dayHours == 'Invalid Date-Invalid Date') return 'Unknown hours';
+    return formattedTimeRange(dayHours) ?? dayHours;
+  }
+
   Widget buildDiningTile(dining_model.DiningModel data, BuildContext context) {
+    String hoursText = _getHoursTextForToday(data.regularHours);
     return Semantics(
       link: true,
-      label: 'Open link. ${data.name}',
+      label: 'Open link. ${data.name}. $hoursText',
       excludeSemantics: true,
       child: ListTile(
       contentPadding: EdgeInsets.zero,

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -218,10 +218,11 @@ class DiningList extends StatelessWidget {
 
   // Builds the Right side of the ListTile containing the icon and distance
   Widget buildIconWithDistance(dining_model.DiningModel data, BuildContext context) {
-    String distanceText = data.distance != null ? '${num.parse(data.distance!.toStringAsFixed(1))} miles' : '';
+    String distanceText = data.distance != null
+        ? '${num.parse(data.distance!.toStringAsFixed(1))} miles, get directions'
+        : 'Get directions';
     return Semantics(
       label: distanceText,
-      button: true,
       excludeSemantics: true,
       child: TextButton(
       style: TextButton.styleFrom(

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -164,35 +164,9 @@ class DiningList extends StatelessWidget {
     );
   }
 
-  String _getHoursTextForToday(dining_model.RegularHours hours) {
-    int weekday = DateTime.now().weekday;
-    String? dayHours;
-    switch (weekday) {
-      case 1: dayHours = hours.mon; break;
-      case 2: dayHours = hours.tue; break;
-      case 3: dayHours = hours.wed; break;
-      case 4: dayHours = hours.thu; break;
-      case 5: dayHours = hours.fri; break;
-      case 6: dayHours = hours.sat; break;
-      case 7: dayHours = hours.sun; break;
-    }
-    if (dayHours == null || dayHours == 'Closed-Closed') {
-      String text = 'Closed';
-      String? nextDay = findNextOpenDay(hours);
-      String? nextTime = findNextOpenTime(hours);
-      if (nextDay != null && nextTime != null) text += '. Opens $nextDay at $nextTime';
-      return text;
-    }
-    if (dayHours == 'Invalid Date-Invalid Date') return 'Unknown hours';
-    return formattedTimeRange(dayHours) ?? dayHours;
-  }
-
   Widget buildDiningTile(dining_model.DiningModel data, BuildContext context) {
-    String hoursText = _getHoursTextForToday(data.regularHours);
     return Semantics(
       link: true,
-      label: 'Open link. ${data.name}. $hoursText',
-      excludeSemantics: true,
       child: ListTile(
       contentPadding: EdgeInsets.zero,
       // Vendor Logo
@@ -219,10 +193,13 @@ class DiningList extends StatelessWidget {
                 color: Theme.of(context).brightness == Brightness.light ? lightPrimaryColor : darkPrimaryColor2),
       ),
       // Vendor Name
-      title: Text(
-        data.name,
-        textAlign: TextAlign.start,
-        style: Theme.of(context).brightness == Brightness.dark ? textButtonSmallDark : textButtonSmallLight,
+      title: Semantics(
+        label: 'Open link',
+        child: Text(
+          data.name,
+          textAlign: TextAlign.start,
+          style: Theme.of(context).brightness == Brightness.dark ? textButtonSmallDark : textButtonSmallLight,
+        ),
       ),
       // Vendor Hours
       subtitle: Padding(

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -165,7 +165,10 @@ class DiningList extends StatelessWidget {
   }
 
   Widget buildDiningTile(dining_model.DiningModel data, BuildContext context) {
-    return ListTile(
+    return Semantics(
+      link: true,
+      label: 'Open link',
+      child: ListTile(
       contentPadding: EdgeInsets.zero,
       // Vendor Logo
       minLeadingWidth: 0, // Reduce minimum width
@@ -207,6 +210,7 @@ class DiningList extends StatelessWidget {
         // if (data.id != null) Provider.of<DiningDataProvider>(context, listen: false).fetchDiningMenu(data.id!);
         Navigator.pushNamed(context, RoutePaths.DINING_OPTION_DETAIL_VIEW, arguments: data);
       },
+    ),
     );
   }
 

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -192,7 +192,8 @@ class DiningList extends StatelessWidget {
       ),
       // Vendor Name
       title: Semantics(
-        label: 'Open link',
+        label: 'Open link. ${data.name}',
+        excludeSemantics: true,
         child: Text(
           data.name,
           textAlign: TextAlign.start,

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -165,10 +165,11 @@ class DiningList extends StatelessWidget {
   }
 
   Widget buildDiningTile(dining_model.DiningModel data, BuildContext context) {
-    return Semantics(
-      link: true,
-      label: 'Open link',
-      child: ListTile(
+    return MergeSemantics(
+      child: Semantics(
+        link: true,
+        label: 'Open link',
+        child: ListTile(
       contentPadding: EdgeInsets.zero,
       // Vendor Logo
       minLeadingWidth: 0, // Reduce minimum width
@@ -210,6 +211,7 @@ class DiningList extends StatelessWidget {
         // if (data.id != null) Provider.of<DiningDataProvider>(context, listen: false).fetchDiningMenu(data.id!);
         Navigator.pushNamed(context, RoutePaths.DINING_OPTION_DETAIL_VIEW, arguments: data);
       },
+    ),
     ),
     );
   }

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -167,7 +167,8 @@ class DiningList extends StatelessWidget {
   Widget buildDiningTile(dining_model.DiningModel data, BuildContext context) {
     return Semantics(
       link: true,
-      hint: 'Open link',
+      label: 'Open link. ${data.name}',
+      excludeSemantics: true,
       child: ListTile(
       contentPadding: EdgeInsets.zero,
       // Vendor Logo

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -165,9 +165,7 @@ class DiningList extends StatelessWidget {
   }
 
   Widget buildDiningTile(dining_model.DiningModel data, BuildContext context) {
-    return Semantics(
-      link: true,
-      child: ListTile(
+    return ListTile(
       contentPadding: EdgeInsets.zero,
       // Vendor Logo
       minLeadingWidth: 0, // Reduce minimum width
@@ -212,7 +210,6 @@ class DiningList extends StatelessWidget {
         // if (data.id != null) Provider.of<DiningDataProvider>(context, listen: false).fetchDiningMenu(data.id!);
         Navigator.pushNamed(context, RoutePaths.DINING_OPTION_DETAIL_VIEW, arguments: data);
       },
-    ),
     );
   }
 

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -169,7 +169,8 @@ class DiningList extends StatelessWidget {
       contentPadding: EdgeInsets.zero,
       // Vendor Logo
       minLeadingWidth: 0, // Reduce minimum width
-      leading: SizedBox(
+      leading: ExcludeSemantics(
+        child: SizedBox(
         width: 48,
         height: 48,
         child: data.vendorLogo != null
@@ -189,6 +190,7 @@ class DiningList extends StatelessWidget {
             : Icon(Icons.restaurant,
                 size: 32,
                 color: Theme.of(context).brightness == Brightness.light ? lightPrimaryColor : darkPrimaryColor2),
+      ),
       ),
       // Vendor Name
       title: Semantics(

--- a/lib/ui/news/news_list.dart
+++ b/lib/ui/news/news_list.dart
@@ -74,10 +74,11 @@ class NewsList extends StatelessWidget {
   }
 
   Widget buildNewsTile(Item newsItem, BuildContext context) {
-    return Semantics(
-      link: true,
-      label: 'Open link',
-      child: GestureDetector(
+    return MergeSemantics(
+      child: Semantics(
+        link: true,
+        label: 'Open link',
+        child: GestureDetector(
         onTap: () {
           Navigator.pushNamed(
             context,
@@ -146,6 +147,7 @@ class NewsList extends StatelessWidget {
             ],
           ),
         ),
+      ),
       ),
       ),
     );

--- a/lib/ui/news/news_list.dart
+++ b/lib/ui/news/news_list.dart
@@ -76,7 +76,7 @@ class NewsList extends StatelessWidget {
   Widget buildNewsTile(Item newsItem, BuildContext context) {
     return Semantics(
       link: true,
-      label: 'Open link. ${newsItem.title}. ${newsItem.description}',
+      label: '${DateFormat.yMMMMd().format(newsItem.date.toLocal())}. Open link. ${newsItem.title}. ${newsItem.description}',
       excludeSemantics: true,
       child: GestureDetector(
         onTap: () {

--- a/lib/ui/news/news_list.dart
+++ b/lib/ui/news/news_list.dart
@@ -74,11 +74,10 @@ class NewsList extends StatelessWidget {
   }
 
   Widget buildNewsTile(Item newsItem, BuildContext context) {
-    return MergeSemantics(
-      child: Semantics(
-        link: true,
-        label: 'Open link',
-        child: GestureDetector(
+    return Semantics(
+      link: true,
+      hint: 'Open link',
+      child: GestureDetector(
         onTap: () {
           Navigator.pushNamed(
             context,
@@ -147,7 +146,6 @@ class NewsList extends StatelessWidget {
             ],
           ),
         ),
-      ),
       ),
       ),
     );

--- a/lib/ui/news/news_list.dart
+++ b/lib/ui/news/news_list.dart
@@ -74,14 +74,17 @@ class NewsList extends StatelessWidget {
   }
 
   Widget buildNewsTile(Item newsItem, BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        Navigator.pushNamed(
-          context,
-          RoutePaths.NEWS_DETAIL_VIEW,
-          arguments: newsItem,
-        );
-      },
+    return Semantics(
+      link: true,
+      label: 'Open link',
+      child: GestureDetector(
+        onTap: () {
+          Navigator.pushNamed(
+            context,
+            RoutePaths.NEWS_DETAIL_VIEW,
+            arguments: newsItem,
+          );
+        },
       child: Container(
         padding: EdgeInsets.all(8.0),
         child: IntrinsicHeight(
@@ -143,6 +146,7 @@ class NewsList extends StatelessWidget {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/ui/news/news_list.dart
+++ b/lib/ui/news/news_list.dart
@@ -76,7 +76,8 @@ class NewsList extends StatelessWidget {
   Widget buildNewsTile(Item newsItem, BuildContext context) {
     return Semantics(
       link: true,
-      hint: 'Open link',
+      label: 'Open link. ${newsItem.title}. ${newsItem.description}',
+      excludeSemantics: true,
       child: GestureDetector(
         onTap: () {
           Navigator.pushNamed(

--- a/lib/ui/parking/circular_parking_indicator.dart
+++ b/lib/ui/parking/circular_parking_indicator.dart
@@ -182,11 +182,15 @@ class CircularParkingIndicators extends StatelessWidget {
   }
 
   Widget buildLocationTitle(BuildContext context) {
-    return Text(
-      model.locationName.toUpperCase(),
-      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.normal,
-          ),
+    return Semantics(
+      label: '${model.locationName.toUpperCase()}. Swipe left or right to view other parking areas',
+      excludeSemantics: true,
+      child: Text(
+        model.locationName.toUpperCase(),
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.normal,
+            ),
+      ),
     );
   }
 

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -96,9 +96,11 @@ class _ParkingCardState extends State<ParkingCard> {
       return Column(
         children: <Widget>[
           Semantics(
-            hint: 'Swipe left or right to view other parking areas',
-            child: Expanded(
-              child: PageView.builder(
+            label: 'Swipe left or right to view other parking areas',
+            child: const SizedBox.shrink(),
+          ),
+          Expanded(
+            child: PageView.builder(
               controller: _controller,
               itemCount: selectedLotsViews.length,
               physics: BouncingScrollPhysics(),
@@ -111,7 +113,6 @@ class _ParkingCardState extends State<ParkingCard> {
                 return selectedLotsViews[index];
               },
             ),
-          ),
           ),
           DotsIndicator(
             position: _currentPage.toDouble(),

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -95,8 +95,10 @@ class _ParkingCardState extends State<ParkingCard> {
 
       return Column(
         children: <Widget>[
-          Expanded(
-            child: PageView.builder(
+          Semantics(
+            hint: 'Swipe left or right to view other parking areas',
+            child: Expanded(
+              child: PageView.builder(
               controller: _controller,
               itemCount: selectedLotsViews.length,
               physics: BouncingScrollPhysics(),
@@ -109,6 +111,7 @@ class _ParkingCardState extends State<ParkingCard> {
                 return selectedLotsViews[index];
               },
             ),
+          ),
           ),
           DotsIndicator(
             position: _currentPage.toDouble(),

--- a/lib/ui/parking/parking_card.dart
+++ b/lib/ui/parking/parking_card.dart
@@ -95,10 +95,6 @@ class _ParkingCardState extends State<ParkingCard> {
 
       return Column(
         children: <Widget>[
-          Semantics(
-            label: 'Swipe left or right to view other parking areas',
-            child: const SizedBox.shrink(),
-          ),
           Expanded(
             child: PageView.builder(
               controller: _controller,

--- a/lib/ui/shuttle/manage_shuttle_view.dart
+++ b/lib/ui/shuttle/manage_shuttle_view.dart
@@ -73,6 +73,7 @@ class _ManageShuttleViewState extends State<ManageShuttleView> {
                   color: Theme.of(context).brightness == Brightness.dark ? linkTextColorDark : linkTextColorLight),
               trailing: IconButton(
                   icon: Icon(Icons.close),
+                  tooltip: 'Remove ${model.name}',
                   onPressed: () async {
                     await _shuttleDataProvider.removeStop(model.id);
                   })),


### PR DESCRIPTION
## Summary
This PR adds
-  [MA 610 and 611, and a checklist item from MA 609]: VO to Business Card (announces "Name [pause] X% busy [pause] view details for name button") 
-  [MA 612]: VO to Shuttle Stops View (announces "remove Name button" for the close button) 
- [MA 613]: Dining Screens: Already had VO for "Get Directions" button. (no changes made for the dining screen)
- [MA 614]: VO to news card (announces "date, open link name [pause] text")
- [MA 615]: VO to announce the interactive slider for parking card (announces "Name [pause] swipe left or right to view other parking areas ... (rest of card)..." ) 
- [MA 616]: VO to announce link for dining card (announces "Open Link, name, hours, Get Directions button") 



## Changelog
[General] [Add] - See above message for specific changes to cards. 


## Test Plan
I tested this by using VoiceOver on IOS and confirm all the cards are reading as expected. 
