### PR TITLE
Set shuttle link and visibility from an external config file

### DIFF
--- a/lib/app_constants.dart
+++ b/lib/app_constants.dart
@@ -89,14 +89,10 @@ class DiningConstants {
 
 class ErrorConstants {
   /// TritonGPT chat / streaming failures (user-facing; no stack traces).
-  static const TRITONGPT_UNAVAILABLE =
-      'Unable to reach TritonGPT right now. Please try again later.';
-  static const TRITONGPT_NOT_FOUND =
-      'TritonGPT could not be reached. Please try again later.';
-  static const TRITONGPT_SERVER_ERROR =
-      'TritonGPT is temporarily unavailable. Please try again later.';
-  static const TRITONGPT_BAD_REQUEST =
-      'Your message could not be processed. Please try again.';
+  static const TRITONGPT_UNAVAILABLE = 'Unable to reach TritonGPT right now. Please try again later.';
+  static const TRITONGPT_NOT_FOUND = 'TritonGPT could not be reached. Please try again later.';
+  static const TRITONGPT_SERVER_ERROR = 'TritonGPT is temporarily unavailable. Please try again later.';
+  static const TRITONGPT_BAD_REQUEST = 'Your message could not be processed. Please try again.';
 
   static const AUTHORIZED_POST_ERRORS = 'Failed to upload data: ';
   static const AUTHORIZED_PUT_ERRORS = 'Failed to update data: ';

--- a/lib/core/models/cards.dart
+++ b/lib/core/models/cards.dart
@@ -15,13 +15,17 @@ class CardsModel {
       required this.initialURL,
       required this.isWebCard,
       required this.requireAuth,
-      required this.titleText});
+      required this.titleText,
+      this.externalLinkURL = '',
+      this.externalLinkText = ''});
 
   bool cardActive;
   String initialURL;
   bool isWebCard;
   bool requireAuth;
   String titleText;
+  String externalLinkURL;
+  String externalLinkText;
 
   factory CardsModel.fromJson(Map<String, dynamic> json) => CardsModel(
         cardActive: json["cardActive"]!,
@@ -29,6 +33,8 @@ class CardsModel {
         isWebCard: json["isWebCard"]!,
         requireAuth: json["requireAuth"]!,
         titleText: json["titleText"]!,
+        externalLinkURL: json["externalLinkURL"] as String? ?? '',
+        externalLinkText: json["externalLinkText"] as String? ?? '',
       );
 
   Map<String, dynamic> toJson() => {
@@ -37,5 +43,7 @@ class CardsModel {
         "isWebCard": isWebCard,
         "requireAuth": requireAuth,
         "titleText": titleText,
+        "externalLinkURL": externalLinkURL,
+        "externalLinkText": externalLinkText,
       };
 }

--- a/lib/core/models/tgpt_models/chat_message_persistent.g.dart
+++ b/lib/core/models/tgpt_models/chat_message_persistent.g.dart
@@ -53,7 +53,5 @@ class ChatMessagePersistentAdapter extends TypeAdapter<ChatMessagePersistent> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ChatMessagePersistentAdapter &&
-          runtimeType == other.runtimeType &&
-          typeId == other.typeId;
+      other is ChatMessagePersistentAdapter && runtimeType == other.runtimeType && typeId == other.typeId;
 }

--- a/lib/core/models/tgpt_models/chat_response.dart
+++ b/lib/core/models/tgpt_models/chat_response.dart
@@ -6,6 +6,7 @@ class BasicCreateChatMessageRequest {
   final String message;
   final String chatSessionId;
   final int? parentMessageId;
+
   /// TGPT web widget sends `window.location.href`; mobile uses a stable context URL.
   final String url;
 

--- a/lib/core/providers/availability.dart
+++ b/lib/core/providers/availability.dart
@@ -29,6 +29,7 @@ class AvailabilityDataProvider extends ChangeNotifier {
 
     if (await _availabilityService.fetchData()) {
       Map<String?, bool> newLocationViewState = {};
+
       /// setting the LocationViewState based on user data
       for (AvailabilityModel model in _availabilityService.data) {
         String curName = model.name;
@@ -43,10 +44,10 @@ class AvailabilityDataProvider extends ChangeNotifier {
 
         if (hasNoSelectedLocations)
           newLocationViewState[curName] = _locationViewState[curName] ?? true;
+
         /// otherwise, LocationViewState should be true for all selectedOccuspaceLocations
         else {
-          newLocationViewState[curName] = _locationViewState[curName] ??
-              selectedLocations.contains(curName);
+          newLocationViewState[curName] = _locationViewState[curName] ?? selectedLocations.contains(curName);
         }
       }
 

--- a/lib/core/providers/chat_provider.dart
+++ b/lib/core/providers/chat_provider.dart
@@ -236,8 +236,7 @@ class ChatProvider extends ChangeNotifier {
         notifyListeners();
       }
     } catch (e) {
-      final String userMessage =
-          e is DioException ? await tgptErrorMessageForDio(e) : tgptErrorMessageFor(e);
+      final String userMessage = e is DioException ? await tgptErrorMessageForDio(e) : tgptErrorMessageFor(e);
       _errorMessage = userMessage;
       final int placeholderIndex =
           sessionMessages.indexWhere((AssistantChatMessage item) => item.id == placeholderMessage.id);

--- a/lib/core/services/tgpt_services/chat_stream.dart
+++ b/lib/core/services/tgpt_services/chat_stream.dart
@@ -101,9 +101,8 @@ class ChatMessageStreamService {
     }
 
     final String? rawContextUrl = dotenv.env['TGPT_CHAT_SEND_CONTEXT_URL'];
-    final String sendContextUrl = (rawContextUrl != null && rawContextUrl.trim().isNotEmpty)
-        ? rawContextUrl.trim()
-        : 'https://mobile.ucsd.edu/';
+    final String sendContextUrl =
+        (rawContextUrl != null && rawContextUrl.trim().isNotEmpty) ? rawContextUrl.trim() : 'https://mobile.ucsd.edu/';
 
     // Build request body using shared helper (includes `url` per TGPT web widget contract)
     final body = ChatMessageService.buildRequestBody(
@@ -154,11 +153,9 @@ class ChatMessageStreamService {
             final Map<String, dynamic> json = jsonDecode(jsonLine) as Map<String, dynamic>;
 
             final Map<String, dynamic>? obj = json['obj'] as Map<String, dynamic>?;
-            final Object? rawReserved =
-                json['reserved_assistant_message_id'] ?? obj?['reserved_assistant_message_id'];
+            final Object? rawReserved = json['reserved_assistant_message_id'] ?? obj?['reserved_assistant_message_id'];
             if (rawReserved != null) {
-              final int? messageId =
-                  rawReserved is int ? rawReserved : int.tryParse(rawReserved.toString());
+              final int? messageId = rawReserved is int ? rawReserved : int.tryParse(rawReserved.toString());
               if (messageId != null) {
                 yield StreamingChatChunk(delta: '', messageId: messageId);
               }

--- a/lib/ui/ai_assistant/chat_message_bubble.dart
+++ b/lib/ui/ai_assistant/chat_message_bubble.dart
@@ -198,9 +198,7 @@ class _RelatedQuestionsSection extends StatelessWidget {
                     child: Material(
                       color: Colors.transparent,
                       child: InkWell(
-                        onTap: enabled
-                            ? () => context.read<ChatProvider>().sendMessage(question)
-                            : null,
+                        onTap: enabled ? () => context.read<ChatProvider>().sendMessage(question) : null,
                         borderRadius: BorderRadius.circular(6),
                         child: Padding(
                           padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 2),

--- a/lib/ui/ai_assistant/citation_web_view.dart
+++ b/lib/ui/ai_assistant/citation_web_view.dart
@@ -25,8 +25,7 @@ class _CitationWebViewState extends State<CitationWebView> {
   void initState() {
     super.initState();
     final Uri? uri = Uri.tryParse(widget.initialUrl);
-    final bool ok =
-        uri != null && uri.hasScheme && (uri.scheme == 'http' || uri.scheme == 'https');
+    final bool ok = uri != null && uri.hasScheme && (uri.scheme == 'http' || uri.scheme == 'https');
     if (!ok) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
@@ -46,9 +45,7 @@ class _CitationWebViewState extends State<CitationWebView> {
   Widget build(BuildContext context) {
     final WebViewController? c = _controller;
     return ContainerView(
-      child: c == null
-          ? const SizedBox.shrink()
-          : WebViewWidget(controller: c),
+      child: c == null ? const SizedBox.shrink() : WebViewWidget(controller: c),
     );
   }
 }

--- a/lib/ui/availability/availability_card.dart
+++ b/lib/ui/availability/availability_card.dart
@@ -44,7 +44,8 @@ class _AvailabilityCardState extends State<AvailabilityCard> {
           _currentPage = 0;
         });
         // check at least one is enabled to avoid crash
-        if (_controller.hasClients) _controller.animateToPage(0, duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+        if (_controller.hasClients)
+          _controller.animateToPage(0, duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
         _availabilityDataProvider.fetchAvailability();
       },
       isLoading: _availabilityDataProvider.isLoading,

--- a/lib/ui/availability/availability_display.dart
+++ b/lib/ui/availability/availability_display.dart
@@ -61,76 +61,77 @@ class AvailabilityDisplay extends StatelessWidget {
               : '${subLocation.name}. ${(100 * percentAvailability(subLocation)).toInt()}% Busy',
           excludeSemantics: true,
           child: GestureDetector(
-          onTap: () {
-            if (subLocation.floors.isNotEmpty) {
-              Navigator.pushNamed(
-                context,
-                RoutePaths.AVAILABILITY_DETAILED_VIEW,
-                arguments: subLocation,
-              );
-            }
-          },
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          subLocation.name,
-                          style: subLocation.floors.isNotEmpty
-                              ? (Theme.of(context).brightness == Brightness.dark
-                                  ? textButtonSmallDark
-                                  : textButtonSmallLight)
-                              : (Theme.of(context).brightness == Brightness.dark
-                                  ? descriptiveTextSmallDark.copyWith(fontSize: 22.0)
-                                  : descriptiveTextSmallLight.copyWith(fontSize: 22.0)),
-                        ),
-                        SizedBox(height: 4),
-                        Text(
-                          '${(100 * percentAvailability(subLocation)).toInt()}% Busy',
-                          style: Theme.of(context).brightness == Brightness.dark
-                              ? textSmallMoreInfoDark
-                              : textSmallMoreInfoLight,
-                        ),
-                      ],
+            onTap: () {
+              if (subLocation.floors.isNotEmpty) {
+                Navigator.pushNamed(
+                  context,
+                  RoutePaths.AVAILABILITY_DETAILED_VIEW,
+                  arguments: subLocation,
+                );
+              }
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            subLocation.name,
+                            style: subLocation.floors.isNotEmpty
+                                ? (Theme.of(context).brightness == Brightness.dark
+                                    ? textButtonSmallDark
+                                    : textButtonSmallLight)
+                                : (Theme.of(context).brightness == Brightness.dark
+                                    ? descriptiveTextSmallDark.copyWith(fontSize: 22.0)
+                                    : descriptiveTextSmallLight.copyWith(fontSize: 22.0)),
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '${(100 * percentAvailability(subLocation)).toInt()}% Busy',
+                            style: Theme.of(context).brightness == Brightness.dark
+                                ? textSmallMoreInfoDark
+                                : textSmallMoreInfoLight,
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                  if (subLocation.floors.isNotEmpty)
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.arrow_forward_ios,
-                          size: 35,
-                          color: Theme.of(context).brightness == Brightness.dark ? linkColorLight : linkColorDark,
-                        ),
-                      ],
-                    ),
-                ],
-              ),
-              SizedBox(
-                height: 6,
-                width: double.infinity,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(BORDER_RADIUS),
-                  child: LinearProgressIndicator(
-                    value:
-                        (percentAvailability(subLocation) <= 0.01) ? 0.01 : percentAvailability(subLocation).toDouble(),
-                    backgroundColor: Colors.grey[BACKGROUND_GREY_SHADE],
-                    valueColor: AlwaysStoppedAnimation<Color>(
-                      setIndicatorColor(percentAvailability(subLocation)),
+                    if (subLocation.floors.isNotEmpty)
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.arrow_forward_ios,
+                            size: 35,
+                            color: Theme.of(context).brightness == Brightness.dark ? linkColorLight : linkColorDark,
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+                SizedBox(
+                  height: 6,
+                  width: double.infinity,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(BORDER_RADIUS),
+                    child: LinearProgressIndicator(
+                      value: (percentAvailability(subLocation) <= 0.01)
+                          ? 0.01
+                          : percentAvailability(subLocation).toDouble(),
+                      backgroundColor: Colors.grey[BACKGROUND_GREY_SHADE],
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        setIndicatorColor(percentAvailability(subLocation)),
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
         ),
       );
     }).toList();

--- a/lib/ui/dining/dining_detail_view.dart
+++ b/lib/ui/dining/dining_detail_view.dart
@@ -278,45 +278,54 @@ Widget buildDirectionsButton(BuildContext context, prefix0.DiningModel model) {
   final bool hasLatitude = hasCoordinates && model.coordinates!.lat != null;
   final bool hasLongitude = hasCoordinates && model.coordinates!.lon != null;
   if (hasCoordinates && hasLatitude && hasLongitude) {
-    return TextButton(
-      child: Row(
-        children: <Widget>[
-          Text(
-            'Get Directions',
-            style: linkTextDark.copyWith(
-              fontSize: 18.0,
-              color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark,
-            ),
-          ),
-          SizedBox(width: 6),
-          Row(
+    return Semantics(
+      label:
+          'Get directions to ${model.name}, ${model.distance != null ? "${model.distance!.toStringAsFixed(1)} miles away" : "distance unknown"}',
+      hint: 'Double tap to open in Maps',
+      button: true,
+      child: ExcludeSemantics(
+        child: TextButton(
+          child: Row(
             children: <Widget>[
-              Icon(
-                Icons.directions_walk,
-                color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark,
-                size: 32,
+              Text(
+                'Get Directions',
+                style: linkTextDark.copyWith(
+                  fontSize: 18.0,
+                  color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark,
+                ),
               ),
-              model.distance != null
-                  ? Text(num.parse(model.distance!.toStringAsFixed(1)).toString() + ' mi',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            fontSize: 18.0,
-                            color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark,
-                          ))
-                  : Text('--', style: TextStyle(color: linkColorLight)),
+              SizedBox(width: 6),
+              Row(
+                children: <Widget>[
+                  Icon(
+                    Icons.directions_walk,
+                    color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark,
+                    size: 32,
+                  ),
+                  model.distance != null
+                      ? Text(num.parse(model.distance!.toStringAsFixed(1)).toString() + ' mi',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                fontSize: 18.0,
+                                color:
+                                    Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark,
+                              ))
+                      : Text('--', style: TextStyle(color: linkColorLight)),
+                ],
+              ),
             ],
           ),
-        ],
-      ),
-      onPressed: () async {
-        try {
-          await DirectionsHelper.openDirections(model.coordinates!.lat!, model.coordinates!.lon!);
-        } catch (e) {
-          // an error occurred, do nothing
-          debugPrint('Error opening directions: $e');
-        }
-      },
-      style: TextButton.styleFrom(
-        padding: EdgeInsets.all(0.0),
+          onPressed: () async {
+            try {
+              await DirectionsHelper.openDirections(model.coordinates!.lat!, model.coordinates!.lon!);
+            } catch (e) {
+              // an error occurred, do nothing
+              debugPrint('Error opening directions: $e');
+            }
+          },
+          style: TextButton.styleFrom(
+            padding: EdgeInsets.all(0.0),
+          ),
+        ),
       ),
     );
   } else {
@@ -331,19 +340,26 @@ Widget buildWebsiteButton(BuildContext context, prefix0.DiningModel model) {
   final bool hasUrl = model.url != null;
   final bool isUrlNotEmpty = hasUrl && model.url != '';
   if (hasUrl && isUrlNotEmpty) {
-    return TextButton(
-      child: Text('Visit Website'),
-      onPressed: () {
-        try {
-          launchUrl(Uri.parse(model.url!), mode: LaunchMode.inAppBrowserView);
-        } catch (e) {
-          // an error occurred, do nothing
-        }
-      },
-      style: TextButton.styleFrom(
-        backgroundColor: actionButtonBackgroundColor,
-        foregroundColor: lightPrimaryColor,
-        padding: EdgeInsets.fromLTRB(20.0, 10, 20.0, 10),
+    return Semantics(
+      label: 'Visit ${model.name} website',
+      hint: 'Double tap to open in browser',
+      button: true,
+      child: ExcludeSemantics(
+        child: TextButton(
+          child: Text('Visit Website'),
+          onPressed: () {
+            try {
+              launchUrl(Uri.parse(model.url!), mode: LaunchMode.inAppBrowserView);
+            } catch (e) {
+              // an error occurred, do nothing
+            }
+          },
+          style: TextButton.styleFrom(
+            backgroundColor: actionButtonBackgroundColor,
+            foregroundColor: lightPrimaryColor,
+            padding: EdgeInsets.fromLTRB(20.0, 10, 20.0, 10),
+          ),
+        ),
       ),
     );
   } else
@@ -354,25 +370,32 @@ Widget buildMenuButton(BuildContext context, prefix0.DiningModel model) {
   final bool hasMenuWebsite = model.menuWebsite != null;
   final bool isMenuWebsiteNotEmpty = hasMenuWebsite && model.menuWebsite!.isNotEmpty;
   if (hasMenuWebsite && isMenuWebsiteNotEmpty) {
-    return TextButton(
-      child: Row(
-        children: [
-          Text('View Menu'),
-          SizedBox(width: 5),
-          Icon(Icons.open_in_new, size: 16),
-        ],
-      ),
-      onPressed: () {
-        try {
-          launch(model.menuWebsite!, forceSafariVC: true);
-        } catch (e) {
-          // an error occurred, do nothing
-        }
-      },
-      style: TextButton.styleFrom(
-        backgroundColor: Color(0xFF00629B),
-        foregroundColor: Colors.white,
-        padding: EdgeInsets.fromLTRB(20.0, 10, 20.0, 10),
+    return Semantics(
+      label: 'View ${model.name} menu',
+      hint: 'Double tap to open in browser',
+      button: true,
+      child: ExcludeSemantics(
+        child: TextButton(
+          child: Row(
+            children: [
+              Text('View Menu'),
+              SizedBox(width: 5),
+              Icon(Icons.open_in_new, size: 16),
+            ],
+          ),
+          onPressed: () {
+            try {
+              launch(model.menuWebsite!, forceSafariVC: true);
+            } catch (e) {
+              // an error occurred, do nothing
+            }
+          },
+          style: TextButton.styleFrom(
+            backgroundColor: Color(0xFF00629B),
+            foregroundColor: Colors.white,
+            padding: EdgeInsets.fromLTRB(20.0, 10, 20.0, 10),
+          ),
+        ),
       ),
     );
   } else {

--- a/lib/ui/dining/dining_list.dart
+++ b/lib/ui/dining/dining_list.dart
@@ -171,26 +171,26 @@ class DiningList extends StatelessWidget {
       minLeadingWidth: 0, // Reduce minimum width
       leading: ExcludeSemantics(
         child: SizedBox(
-        width: 48,
-        height: 48,
-        child: data.vendorLogo != null
-            ? Container(
-                decoration: Theme.of(context).brightness == Brightness.dark
-                    ? BoxDecoration(
-                        color: lightTextColor,
-                        borderRadius: BorderRadius.circular(8),
-                      )
-                    : null,
-                child: Image.network(
-                  data.vendorLogo!,
-                  width: 48,
-                  height: 48,
-                ),
-              )
-            : Icon(Icons.restaurant,
-                size: 32,
-                color: Theme.of(context).brightness == Brightness.light ? lightPrimaryColor : darkPrimaryColor2),
-      ),
+          width: 48,
+          height: 48,
+          child: data.vendorLogo != null
+              ? Container(
+                  decoration: Theme.of(context).brightness == Brightness.dark
+                      ? BoxDecoration(
+                          color: lightTextColor,
+                          borderRadius: BorderRadius.circular(8),
+                        )
+                      : null,
+                  child: Image.network(
+                    data.vendorLogo!,
+                    width: 48,
+                    height: 48,
+                  ),
+                )
+              : Icon(Icons.restaurant,
+                  size: 32,
+                  color: Theme.of(context).brightness == Brightness.light ? lightPrimaryColor : darkPrimaryColor2),
+        ),
       ),
       // Vendor Name
       title: Semantics(
@@ -225,29 +225,30 @@ class DiningList extends StatelessWidget {
       label: distanceText,
       excludeSemantics: true,
       child: TextButton(
-      style: TextButton.styleFrom(
-        foregroundColor: linkColorLight,
+        style: TextButton.styleFrom(
+          foregroundColor: linkColorLight,
+        ),
+        onPressed: () async {
+          try {
+            await DirectionsHelper.openDirections(data.coordinates!.lat!, data.coordinates!.lon!);
+          } catch (e) {
+            // an error occurred, do nothing
+          }
+        },
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.directions_walk,
+                size: 28, color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark),
+            Text(
+              data.distance != null ? (num.parse(data.distance!.toStringAsFixed(1)).toString() + ' mi') : '--',
+              style: TextStyle(
+                  fontSize: 13,
+                  color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark),
+            ),
+          ],
+        ),
       ),
-      onPressed: () async {
-        try {
-          await DirectionsHelper.openDirections(data.coordinates!.lat!, data.coordinates!.lon!);
-        } catch (e) {
-          // an error occurred, do nothing
-        }
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.directions_walk,
-              size: 28, color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark),
-          Text(
-            data.distance != null ? (num.parse(data.distance!.toStringAsFixed(1)).toString() + ' mi') : '--',
-            style: TextStyle(
-                fontSize: 13, color: Theme.of(context).brightness == Brightness.light ? linkColorLight : linkColorDark),
-          ),
-        ],
-      ),
-    ),
     );
   }
 }

--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -164,11 +164,14 @@ class _HomeState extends State<Home> {
     return [...noticesCards, ...orderedCards];
   }
 
-  List<Widget> getNoticesCardsList(List<NoticesModel> notices) =>
-      notices.asMap().entries.map((e) => CardViewTrackingWrapper(
+  List<Widget> getNoticesCardsList(List<NoticesModel> notices) => notices
+      .asMap()
+      .entries
+      .map((e) => CardViewTrackingWrapper(
             cardId: 'notice_${e.key}',
             child: NoticesCard(notice: e.value),
-          )).toList();
+          ))
+      .toList();
 
   // Constructor tear-offs used below to generate ordered cards list in O(1) time
   static const _CARD_CTORS = {

--- a/lib/ui/navigator/bottom.dart
+++ b/lib/ui/navigator/bottom.dart
@@ -29,8 +29,7 @@ class BottomTabBar extends StatefulWidget {
 }
 
 class _BottomTabBarState extends State<BottomTabBar> {
-  
-    var currentTab = [
+  var currentTab = [
     Home(),
     prefix0.Maps(),
     AIAssistantTab(),

--- a/lib/ui/news/news_list.dart
+++ b/lib/ui/news/news_list.dart
@@ -76,7 +76,8 @@ class NewsList extends StatelessWidget {
   Widget buildNewsTile(Item newsItem, BuildContext context) {
     return Semantics(
       link: true,
-      label: '${DateFormat.yMMMMd().format(newsItem.date.toLocal())}. Open link. ${newsItem.title}. ${newsItem.description}',
+      label:
+          '${DateFormat.yMMMMd().format(newsItem.date.toLocal())}. Open link. ${newsItem.title}. ${newsItem.description}',
       excludeSemantics: true,
       child: GestureDetector(
         onTap: () {
@@ -86,68 +87,68 @@ class NewsList extends StatelessWidget {
             arguments: newsItem,
           );
         },
-      child: Container(
-        padding: EdgeInsets.all(8.0),
-        child: IntrinsicHeight(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 140,
-                margin: EdgeInsets.only(right: 8.0),
-                child: ImageLoader(
-                  url: newsItem.image,
-                  fullSize: true,
-                  fit: BoxFit.cover,
+        child: Container(
+          padding: EdgeInsets.all(8.0),
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 140,
+                  margin: EdgeInsets.only(right: 8.0),
+                  child: ImageLoader(
+                    url: newsItem.image,
+                    fullSize: true,
+                    fit: BoxFit.cover,
+                  ),
                 ),
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    RichText(
-                      textScaler: MediaQuery.textScalerOf(context),
-                      text: TextSpan(
-                        children: [
-                          TextSpan(
-                            text: DateFormat.yMMMMd().format(newsItem.date.toLocal()),
-                            style: TextStyle(
-                              fontSize: 16.0,
-                              fontWeight: FontWeight.bold,
-                              height: 1.42,
-                              color: Theme.of(context).textTheme.bodyMedium!.color,
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      RichText(
+                        textScaler: MediaQuery.textScalerOf(context),
+                        text: TextSpan(
+                          children: [
+                            TextSpan(
+                              text: DateFormat.yMMMMd().format(newsItem.date.toLocal()),
+                              style: TextStyle(
+                                fontSize: 16.0,
+                                fontWeight: FontWeight.bold,
+                                height: 1.42,
+                                color: Theme.of(context).textTheme.bodyMedium!.color,
+                              ),
                             ),
-                          ),
-                          TextSpan(
-                            text: ' - ',
-                            style: Theme.of(context)
-                                .textTheme
-                                .headlineMedium!
-                                .copyWith(height: 1.42, fontSize: 16.0, decoration: TextDecoration.none),
-                          ),
-                          TextSpan(
-                            text: newsItem.title,
-                            style: Theme.of(context).textTheme.headlineMedium!.copyWith(height: 1.42, fontSize: 18.0),
-                          ),
-                        ],
+                            TextSpan(
+                              text: ' - ',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .headlineMedium!
+                                  .copyWith(height: 1.42, fontSize: 16.0, decoration: TextDecoration.none),
+                            ),
+                            TextSpan(
+                              text: newsItem.title,
+                              style: Theme.of(context).textTheme.headlineMedium!.copyWith(height: 1.42, fontSize: 18.0),
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
-                    SizedBox(height: 8),
-                    Text(
-                      newsItem.description,
-                      textAlign: TextAlign.start,
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 2,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 16.0, height: 1.42),
-                    ),
-                  ],
+                      SizedBox(height: 8),
+                      Text(
+                        newsItem.description,
+                        textAlign: TextAlign.start,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 2,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 16.0, height: 1.42),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }

--- a/lib/ui/shuttle/shuttle_card.dart
+++ b/lib/ui/shuttle/shuttle_card.dart
@@ -16,8 +16,6 @@ import 'package:url_launcher/url_launcher.dart';
 
 const String cardId = 'shuttle';
 
-const String _wayfinderTransitMapUrl = 'https://wayfinder.ucsd.onebusawaycloud.com/';
-
 class ShuttleCard extends StatefulWidget {
   @override
   _ShuttleCardState createState() => _ShuttleCardState();
@@ -41,6 +39,36 @@ class _ShuttleCardState extends State<ShuttleCard> {
   }
 
   Widget build(BuildContext context) {
+    final shuttleCardConfig = context.select((CardsDataProvider p) => p.availableCards[cardId]);
+    final externalLinkURL = shuttleCardConfig?.externalLinkURL.trim() ?? '';
+    final externalLinkText = shuttleCardConfig?.externalLinkText ?? '';
+    final actionButtonChildren = <Widget>[
+      if (externalLinkURL.isNotEmpty) ...[
+        ActionButton(
+          buttonText: externalLinkText,
+          trailingIcon: Icons.open_in_new,
+          onPressed: () {
+            analytics.logEvent(name: '${cardId}_card_action', parameters: {'action': 'view_live_transit_map'});
+            try {
+              launchUrl(Uri.parse(externalLinkURL), mode: LaunchMode.inAppBrowserView);
+            } catch (e) {
+              // an error occurred, do nothing
+            }
+          },
+        ),
+        const SizedBox(height: 16),
+      ],
+      ActionLink(
+          buttonText: 'MANAGE SHUTTLE STOPS',
+          onPressed: () {
+            analytics.logEvent(name: '${cardId}_card_action', parameters: {'action': 'manage_stops'});
+            setState(() {
+              _currentPage = 0;
+            });
+            Navigator.pushNamed(context, RoutePaths.MANAGE_SHUTTLE_VIEW);
+          }),
+    ];
+
     return CardContainer(
       cardId: cardId,
       active: context.select((CardsDataProvider p) => p.cardStates[cardId] ?? false),
@@ -60,30 +88,7 @@ class _ShuttleCardState extends State<ShuttleCard> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
-            children: [
-              ActionButton(
-                buttonText: 'VIEW LIVE TRANSIT MAP',
-                trailingIcon: Icons.open_in_new,
-                onPressed: () {
-                  analytics.logEvent(name: '${cardId}_card_action', parameters: {'action': 'view_live_transit_map'});
-                  try {
-                    launchUrl(Uri.parse(_wayfinderTransitMapUrl), mode: LaunchMode.inAppBrowserView);
-                  } catch (e) {
-                    // an error occurred, do nothing
-                  }
-                },
-              ),
-              const SizedBox(height: 16),
-              ActionLink(
-                  buttonText: 'MANAGE SHUTTLE STOPS',
-                  onPressed: () {
-                    analytics.logEvent(name: '${cardId}_card_action', parameters: {'action': 'manage_stops'});
-                    setState(() {
-                      _currentPage = 0;
-                    });
-                    Navigator.pushNamed(context, RoutePaths.MANAGE_SHUTTLE_VIEW);
-                  }),
-            ],
+            children: actionButtonChildren,
           ),
         ),
       ],


### PR DESCRIPTION
```markdown
## Summary

Updates the Shuttle card’s external transit map action to come from a config file, allowing the button label, destination, and visibility to be configured external to the app.


## Changelog

[General] [Change] - Configure the Shuttle card external link button from the cards list response and hide it when no external URL is provided.


## Test Plan

- Verified `CardsModel` parses optional `externalLinkURL` and `externalLinkText` fields with empty-string defaults.
- Verified Shuttle card no longer uses the hardcoded Wayfinder URL.
- Verified the external link button is only rendered when `externalLinkURL.trim()` is non-empty.
- Ran targeted Flutter analysis on the updated model and Shuttle card files.
```