### PR TITLE
(MA-649) Changed Parking, Hydration, and ATM buttons colors

### DIFF
--- a/lib/ui/map/quick_search_icons.dart
+++ b/lib/ui/map/quick_search_icons.dart
@@ -63,7 +63,7 @@ class LabeledIconButton extends StatelessWidget {
       children: <Widget>[
         MaterialButton(
           onPressed: onPressed as void Function()?,
-          color: Colors.red,
+          color: Color(0xFF00629B),
           textColor: Colors.white,
           child: Icon(
             icon,


### PR DESCRIPTION
## Summary
MA-649: https://its-pro.ucsd.edu/browse/MA-649
Parking, Hydration, and ATM icon backgrounds are the wrong color in the Map Search Tab.

Changed Parking, Hydration, and ATM icon colors to #00629B (solid blue).

BEFORE:

<img width="472" height="1024" alt="image" src="https://github.com/user-attachments/assets/6daef316-140c-43dc-ac02-346fd397909f" />

AFTER:

<img width="1075" height="2392" alt="share_9033761770333400751" src="https://github.com/user-attachments/assets/c8bb555e-25a8-4ac1-8d0b-58fc5b72407f" />


## Changelog
[General] [Fix] - Changed Color of mentioned icons.


## Test Plan
Ensure the icons are set to color #00629B (muted, cold blue)

Testing Spreadsheet: https://ucsdcloud.sharepoint.com/:x:/s/WorkplaceTechnologyServices-CampusMobileBuilds/IQCVE3EiPpq2S6hASRKUmStpAde7GNk7z__NoaIfHiW0BO0?e=3shYT4

