### PR TITLE
Changed Parking, Hydration, and ATM buttons colors

### DIFF
--- a/lib/ui/map/quick_search_icons.dart
+++ b/lib/ui/map/quick_search_icons.dart
@@ -63,7 +63,7 @@ class LabeledIconButton extends StatelessWidget {
       children: <Widget>[
         MaterialButton(
           onPressed: onPressed as void Function()?,
-          color: Colors.red,
+          color: Color(0xFF00629B),
           textColor: Colors.white,
           child: Icon(
             icon,


### PR DESCRIPTION
## Summary
MA-649 Parking, Hydration, and ATM icon backgrounds are the wrong color

Changed Parking, Hydration, and ATM icon colors to #00629B


## Changelog
[General] [Fix] - Changed Color of mentioned icons.


## Test Plan
Ensure the icons are set to color #00629B (muted, cold blue)

