### PR TITLE
Fix Android notification channel handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -76,5 +76,8 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_color"
             android:resource="@color/colorAccent" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/default_notification_channel_id" />
     </application>
 </manifest>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="default_notification_channel_id">campus_mobile_notifications</string>
+</resources>

--- a/lib/core/providers/messages.dart
+++ b/lib/core/providers/messages.dart
@@ -38,6 +38,10 @@ class MessagesDataProvider extends ChangeNotifier {
 
   // Fetch messages
   Future<bool> fetchMessages(bool clearMessages) async {
+    debugPrint(
+      '[Messages] fetchMessages start clear=$clearMessages '
+      'loggedIn=${userDataProvider?.isLoggedIn} raw=${_messages.length} visible=${messages.length}',
+    );
     _isLoading = true;
     _error = null;
     notifyListeners();
@@ -48,6 +52,11 @@ class MessagesDataProvider extends ChangeNotifier {
           : await retrieveMoreTopicMessages();
     } finally {
       _isLoading = false;
+      debugPrint(
+        '[Messages] fetchMessages done clear=$clearMessages error=$_error '
+        'raw=${_messages.length} visible=${messages.length}',
+      );
+      notifyListeners();
     }
   }
 
@@ -70,6 +79,8 @@ class MessagesDataProvider extends ChangeNotifier {
 
     if (await _messageService.fetchMyMessagesData(timestamp, headers)) {
       List<MessageElement> temp = _messageService.messagingModels.messages;
+      final directCount = temp.where((message) => message.audience.topics == null).length;
+      debugPrint('[Messages] retrieveMoreMyMessages fetched=${temp.length} direct=$directCount timestamp=$timestamp');
       updateMessages(temp);
       makeOrderedMessagesList();
       returnedTimestamp = _messageService.messagingModels.next ?? 0;
@@ -81,6 +92,8 @@ class MessagesDataProvider extends ChangeNotifier {
       notifyListeners();
       return true;
     }
+    _error = _messageService.error;
+    debugPrint('[Messages] retrieveMoreMyMessages failed: $_error');
     return false;
   }
 
@@ -90,10 +103,16 @@ class MessagesDataProvider extends ChangeNotifier {
     notifyListeners();
     int returnedTimestamp;
 
-    final bool topicDataFetched =
-        await _messageService.fetchTopicData(_previousTimestamp, userDataProvider!.subscribedTopics!);
+    final bool topicDataFetched = await _messageService.fetchTopicData(
+      _previousTimestamp,
+      userDataProvider!.subscribedTopics!,
+    );
     if (topicDataFetched) {
       List<MessageElement> temp = _messageService.messagingModels.messages;
+      debugPrint(
+        '[Messages] retrieveMoreTopicMessages fetched=${temp.length} '
+        'topics=${userDataProvider!.subscribedTopics}',
+      );
       updateMessages(temp);
       makeOrderedMessagesList();
       returnedTimestamp = _messageService.messagingModels.next ?? 0;
@@ -134,8 +153,10 @@ class MessagesDataProvider extends ChangeNotifier {
   ScrollController get scrollController => notificationScrollController;
   List<MessageElement> get messages {
     final subscribedTopics = userDataProvider?.subscribedTopics ?? [];
-    return _messages
-        .where((message) => (message.audience.topics ?? const ['DM']).any(subscribedTopics.contains))
-        .toList();
+    return _messages.where((message) {
+      final topics = message.audience.topics;
+      if (topics == null) return userDataProvider?.isLoggedIn ?? false;
+      return topics.any(subscribedTopics.contains);
+    }).toList();
   }
 }

--- a/lib/core/providers/notifications.dart
+++ b/lib/core/providers/notifications.dart
@@ -15,6 +15,10 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const String _androidNotificationChannelId = 'campus_mobile_notifications';
+const String _androidNotificationChannelName = 'Campus Mobile Notifications';
+const String _androidNotificationChannelDescription = 'Campus Mobile alerts and messages';
+
 class PushNotificationDataProvider extends ChangeNotifier {
   PushNotificationDataProvider() {
     initState();
@@ -64,20 +68,31 @@ class PushNotificationDataProvider extends ChangeNotifier {
   var flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
   static const String _NOTIFICATION_PERMISSION_REQUESTED_KEY = 'notification_permission_requested';
+  bool _platformStateInitialized = false;
 
   /// Configures the [_fcm] object to receive push notifications
   Future<void> initPlatformState(BuildContext context) async {
     try {
       /// Initialize flutter notification settings
       this.context = context;
+      if (_platformStateInitialized) {
+        debugPrint('[PushNotifications] initPlatformState skipped; already initialized');
+        return;
+      }
+      _platformStateInitialized = true;
+      debugPrint('[PushNotifications] initPlatformState starting');
 
       /// Request notification permission on Android once (early, like iOS)
       if (Platform.isAndroid) {
         final prefs = await SharedPreferences.getInstance();
         var isPermissionRequested = prefs.getBool(_NOTIFICATION_PERMISSION_REQUESTED_KEY) ?? false;
         if (!isPermissionRequested) {
-          await FirebaseMessaging.instance.requestPermission();
+          final settings = await FirebaseMessaging.instance.requestPermission();
+          debugPrint('[PushNotifications] Android permission requested: ${settings.authorizationStatus}');
           await prefs.setBool(_NOTIFICATION_PERMISSION_REQUESTED_KEY, true);
+        } else {
+          final settings = await FirebaseMessaging.instance.getNotificationSettings();
+          debugPrint('[PushNotifications] Android permission already requested: ${settings.authorizationStatus}');
         }
       }
 
@@ -87,10 +102,12 @@ class PushNotificationDataProvider extends ChangeNotifier {
           InitializationSettings(android: initializationSettingsAndroid, iOS: initializationSettingsIOS);
       await flutterLocalNotificationsPlugin.initialize(initializationSettings,
           onDidReceiveNotificationResponse: selectNotification);
+      if (Platform.isAndroid) await _createAndroidNotificationChannel();
 
       RemoteMessage? initialMessage = await FirebaseMessaging.instance.getInitialMessage();
 
       if (initialMessage != null) {
+        _logRemoteMessage('initialMessage', initialMessage);
         await Provider.of<MessagesDataProvider>(context, listen: false).fetchMessages(true);
 
         /// switch to the notifications tab
@@ -100,6 +117,8 @@ class PushNotificationDataProvider extends ChangeNotifier {
 
       /// Foreground messaging
       FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+        _logRemoteMessage('onMessage', message);
+
         /// foreground messaging callback via flutter_local_notifications
         /// only show message if the message has not been seen before
         final bool isNewMessage = !_receivedMessageIds.contains(message.messageId);
@@ -113,6 +132,8 @@ class PushNotificationDataProvider extends ChangeNotifier {
 
       FirebaseMessaging.onMessageOpenedApp.listen(
         (RemoteMessage message) {
+          _logRemoteMessage('onMessageOpenedApp', message);
+
           /// Fetch in-app messages
           Provider.of<MessagesDataProvider>(context, listen: false).fetchMessages(true);
 
@@ -127,6 +148,7 @@ class PushNotificationDataProvider extends ChangeNotifier {
       );
     } on PlatformException {
       _error = 'Failed to get platform info.';
+      _platformStateInitialized = false;
     }
   }
 
@@ -147,19 +169,50 @@ class PushNotificationDataProvider extends ChangeNotifier {
 
   /// Displays the notification
   showNotification(RemoteMessage message) async {
-    const androidPlatformChannelSpecifics = AndroidNotificationDetails('your channel id', 'your channel name',
-        icon: '@drawable/ic_notif_round',
-        largeIcon: const DrawableResourceAndroidBitmap('@drawable/app_icon'),
-        importance: Importance.max,
-        priority: Priority.high,
-        showWhen: false);
+    debugPrint(
+      '[PushNotifications] showNotification start channel=$_androidNotificationChannelId '
+      'messageId=${message.messageId}',
+    );
+    const androidPlatformChannelSpecifics = AndroidNotificationDetails(
+      _androidNotificationChannelId,
+      _androidNotificationChannelName,
+      channelDescription: _androidNotificationChannelDescription,
+      icon: '@drawable/ic_notif_round',
+      largeIcon: const DrawableResourceAndroidBitmap('@drawable/app_icon'),
+      importance: Importance.max,
+      priority: Priority.high,
+      showWhen: false,
+    );
     const DarwinNotificationDetails();
     const platformChannelSpecifics =
         NotificationDetails(android: androidPlatformChannelSpecifics, iOS: DarwinNotificationDetails());
     // This is where you put info from firebase
-    await flutterLocalNotificationsPlugin.show(
-        0, message.notification!.title, message.notification!.body, platformChannelSpecifics,
-        payload: 'This is the payload');
+    try {
+      await flutterLocalNotificationsPlugin.show(
+        DateTime.now().millisecondsSinceEpoch.remainder(100000),
+        message.notification?.title ?? message.data['title']?.toString(),
+        message.notification?.body ?? message.data['body']?.toString(),
+        platformChannelSpecifics,
+        payload: 'This is the payload',
+      );
+      debugPrint('[PushNotifications] showNotification posted messageId=${message.messageId}');
+    } catch (error, stackTrace) {
+      debugPrint('[PushNotifications] showNotification failed: $error');
+      debugPrint(stackTrace.toString());
+    }
+  }
+
+  Future<void> _createAndroidNotificationChannel() async {
+    const channel = AndroidNotificationChannel(
+      _androidNotificationChannelId,
+      _androidNotificationChannelName,
+      description: _androidNotificationChannelDescription,
+      importance: Importance.max,
+    );
+    await flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(channel);
+    debugPrint('[PushNotifications] Android channel ensured: $_androidNotificationChannelId');
   }
 
   /// Fetches topics from endpoint
@@ -238,23 +291,49 @@ class PushNotificationDataProvider extends ChangeNotifier {
       return false;
     } else {
       // Get the token for this device
-      String? fcmToken = await _fcm.getToken();
+      String? fcmToken;
+      try {
+        fcmToken = await _fcm.getToken();
+      } catch (error, stackTrace) {
+        _error = 'Failed to get firebase token: $error';
+        debugPrint('[PushNotifications] registerDevice getToken failed: $error');
+        debugPrint(stackTrace.toString());
+        return false;
+      }
       final bool hasFcmToken = fcmToken != null && fcmToken.isNotEmpty;
       final bool hasAccessToken = accessToken?.isNotEmpty ?? false;
+      debugPrint(
+        '[PushNotifications] registerDevice deviceId=$deviceId '
+        'hasFcmToken=$hasFcmToken hasAccessToken=$hasAccessToken',
+      );
       if (hasFcmToken && hasAccessToken) {
         Map<String, String> headers = {'Authorization': 'Bearer ' + accessToken!};
         Map<String, String> body = {'deviceId': deviceId, 'token': fcmToken};
         if ((await _notificationService.postPushToken(headers, body))) {
+          debugPrint('[PushNotifications] registerDevice postPushToken succeeded');
           return true;
         } else {
           _error = _notificationService.error;
+          debugPrint('[PushNotifications] registerDevice postPushToken failed: $_error');
           return false;
         }
       } else {
         _error = 'Failed to get firebase token.';
+        debugPrint('[PushNotifications] registerDevice failed: $_error');
         return false;
       }
     }
+  }
+
+  void _logRemoteMessage(String source, RemoteMessage message) {
+    debugPrint(
+      '[PushNotifications] $source '
+      'messageId=${message.messageId} '
+      'hasNotification=${message.notification != null} '
+      'title=${message.notification?.title ?? message.data['title']} '
+      'body=${message.notification?.body ?? message.data['body']} '
+      'data=${message.data}',
+    );
   }
 
   /// Unregisters device from receiving push notifications

--- a/lib/core/wrappers/push_notifications.dart
+++ b/lib/core/wrappers/push_notifications.dart
@@ -14,7 +14,7 @@ class _PushNotificationWrapperState extends State<PushNotificationWrapper> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    Provider.of<PushNotificationDataProvider>(context).initPlatformState(context);
+    Provider.of<PushNotificationDataProvider>(context, listen: false).initPlatformState(context);
   }
 
   @override

--- a/test/core/providers/messages_test.dart
+++ b/test/core/providers/messages_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('messages only includes currently subscribed notification types', () {
-    final user = _UserDataProvider(['staffAnnouncements']);
+    final user = _UserDataProvider(['staffAnnouncements'], isLoggedIn: false);
     final provider = MessagesDataProvider()..userDataProvider = user;
     provider.updateMessages([
       _message('staff', ['staffAnnouncements']),
@@ -15,7 +15,19 @@ void main() {
     expect(provider.messages.map((message) => message.messageId), ['staff']);
 
     user.topics = ['DM'];
+    user.loggedIn = true;
     expect(provider.messages.map((message) => message.messageId), ['scan']);
+  });
+
+  test('messages includes direct notifications for logged-in users', () {
+    final user = _UserDataProvider(['staffAnnouncements'], isLoggedIn: true);
+    final provider = MessagesDataProvider()..userDataProvider = user;
+    provider.updateMessages([
+      _message('staff', ['staffAnnouncements']),
+      _message('direct', null),
+    ]);
+
+    expect(provider.messages.map((message) => message.messageId), ['staff', 'direct']);
   });
 }
 
@@ -28,9 +40,13 @@ MessageElement _message(String id, List<String>? topics) => MessageElement(
     );
 
 class _UserDataProvider extends UserDataProvider {
-  _UserDataProvider(this.topics);
+  _UserDataProvider(this.topics, {required bool isLoggedIn}) : loggedIn = isLoggedIn;
 
   List<String?> topics;
+  bool loggedIn;
+
+  @override
+  bool get isLoggedIn => loggedIn;
 
   @override
   List<String?>? get subscribedTopics => topics;


### PR DESCRIPTION
## Summary
Fixes Android notification handling so foreground and background FCM notifications use a stable high-importance notification channel. Also prevents repeated push listener initialization and preserves direct-message visibility for logged-in users.

## Changelog
[Android] [Fix] - Add a stable max-importance notification channel for Campus Mobile notifications and wire it as the default FCM channel
[General] [Fix] - Prevent repeated push notification initialization from registering duplicate FCM listeners
[General] [Fix] - Ensure direct messages are visible in the notifications list for logged-in users

## Test Plan
- Tested on Pixel device