### PR TITLE
[MA6-44] Fixed "New Chat" Icon Color

### DIFF
--- a/lib/ui/ai_assistant/ai_assistant_view.dart
+++ b/lib/ui/ai_assistant/ai_assistant_view.dart
@@ -20,7 +20,7 @@ class AIAssistantView extends StatefulWidget {
 
 class _AIAssistantViewState extends State<AIAssistantView> {
   static const Color _SIDEBAR_ICON_COLOR = Color(0xFF747678);
-  static const Color _NEW_CHAT_ICON_COLOR = Color(0xFF00629B);
+  static const Color _NEW_CHAT_ICON_COLOR = Color(0xFF6C95B8);
 
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   bool _isSidebarOpen = false;
@@ -98,20 +98,13 @@ class _AIAssistantViewState extends State<AIAssistantView> {
             AbsorbPointer(
               absorbing: _isSidebarOpen,
               child: ImageFiltered(
-                imageFilter: ImageFilter.blur(
-                  sigmaX: _isSidebarOpen ? 8 : 0,
-                  sigmaY: _isSidebarOpen ? 8 : 0,
-                ),
+                imageFilter: ImageFilter.blur(sigmaX: _isSidebarOpen ? 8 : 0, sigmaY: _isSidebarOpen ? 8 : 0),
                 child: _buildMainContent(chatProvider),
               ),
             ),
             if (_isSidebarOpen)
               Positioned.fill(
-                child: IgnorePointer(
-                  child: Container(
-                    color: const Color(0xFF182B49).withValues(alpha: 0.10),
-                  ),
-                ),
+                child: IgnorePointer(child: Container(color: const Color(0xFF182B49).withValues(alpha: 0.10))),
               ),
           ],
         ),
@@ -160,8 +153,9 @@ class _AIAssistantViewState extends State<AIAssistantView> {
           ),
         ),
         Expanded(
-          child:
-              chatProvider.hasMessages ? ChatMessageList(messages: chatProvider.messages) : const AssistantEmptyState(),
+          child: chatProvider.hasMessages
+              ? ChatMessageList(messages: chatProvider.messages)
+              : const AssistantEmptyState(),
         ),
       ],
     );
@@ -179,9 +173,7 @@ class _AIAssistantViewState extends State<AIAssistantView> {
     _lastShownError = errorMessage;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(errorMessage)),
-      );
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(errorMessage)));
     });
   }
 


### PR DESCRIPTION
## Summary
Fixed "new chat" icon color to a lighter blue.
<img width=50% height=50% alt="Screenshot_20260805_133622" src="https://github.com/user-attachments/assets/5a80f8d2-e3eb-411a-b218-fc186869fb69" />


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Change] - Message


## Test Plan
Already tested in #2331 

