### PR TITLE
[MA-679] Small VO Improvement

### DIFF
--- a/lib/ui/events/events_detail_view.dart
+++ b/lib/ui/events/events_detail_view.dart
@@ -33,15 +33,17 @@ class EventDetailView extends StatelessWidget {
           child: Row(
             children: [
               // Event Date
-              Builder(builder: (context) {
-                final df = DateFormat("MMM d y");
-                final localStart = data.startDate.toLocal();
-                final localEnd = data.endDate.toLocal();
-                final startDate = df.format(localStart);
-                final endDate = df.format(localEnd);
-                final dateDisplay = startDate == endDate ? startDate : '$startDate - $endDate';
-                return StartEndDateContainer(date: dateDisplay);
-              }),
+              Builder(
+                builder: (context) {
+                  final df = DateFormat("MMM d y");
+                  final localStart = data.startDate.toLocal();
+                  final localEnd = data.endDate.toLocal();
+                  final startDate = df.format(localStart);
+                  final endDate = df.format(localEnd);
+                  final dateDisplay = startDate == endDate ? startDate : '$startDate - $endDate';
+                  return StartEndDateContainer(date: dateDisplay);
+                },
+              ),
 
               // Event Title
               Expanded(child: EventTitle(title: data.title)),
@@ -49,8 +51,9 @@ class EventDetailView extends StatelessWidget {
           ),
         ),
         Container(
-            padding: const EdgeInsets.only(left: 17.0),
-            child: Row(children: [
+          padding: const EdgeInsets.only(left: 17.0),
+          child: Row(
+            children: [
               // Event Location
               Icon(
                 Icons.location_on_sharp,
@@ -61,7 +64,7 @@ class EventDetailView extends StatelessWidget {
               Expanded(
                 child: data.location != null && data.location!.isNotEmpty
                     ? Semantics(
-                        label: 'Location: ',
+                        label: 'Location: ${data.location}',
                         child: LinkifyWithCatch(
                           text: data.location!,
                           looseUrl: true,
@@ -76,49 +79,54 @@ class EventDetailView extends StatelessWidget {
               ),
               SizedBox(width: 5),
               // Event Time
-              Builder(builder: (context) {
-                final timeString = data.startDate.toLocal().hour == 0 && data.endDate.toLocal().hour == 23
-                    ? '    All day     '
-                    : DateFormat.jm().format(data.startDate.toLocal()) +
-                        ' - ' +
-                        DateFormat.jm().format(data.endDate.toLocal());
-                final semanticTime = 'From: ' + timeString.replaceAll('-', 'to').trim();
-                return Semantics(
-                  container: true,
-                  child: Text(
-                    timeString,
-                    semanticsLabel: semanticTime,
-                    style: TextStyle(
-                      fontSize: 16,
-                      color: Theme.of(context).brightness == Brightness.light ? lightPrimaryColor : Colors.white,
-                      fontWeight: FontWeight.w400,
+              Builder(
+                builder: (context) {
+                  final timeString = data.startDate.toLocal().hour == 0 && data.endDate.toLocal().hour == 23
+                      ? '    All day     '
+                      : DateFormat.jm().format(data.startDate.toLocal()) +
+                            ' - ' +
+                            DateFormat.jm().format(data.endDate.toLocal());
+                  final semanticTime = 'From: ' + timeString.replaceAll('-', 'to').trim();
+                  return Semantics(
+                    container: true,
+                    child: Text(
+                      timeString,
+                      semanticsLabel: semanticTime,
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Theme.of(context).brightness == Brightness.light ? lightPrimaryColor : Colors.white,
+                        fontWeight: FontWeight.w400,
+                      ),
                     ),
-                  ),
-                );
-              }),
+                  );
+                },
+              ),
               SizedBox(width: 16),
-            ])),
+            ],
+          ),
+        ),
         Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Column(
-              children: [
-                ///////////////// Horizontal Division ///////////////////
-                Divider(color: listTileDividerColorDark, thickness: 0.6),
-                // Event Description
-                data.description != null && data.description!.isNotEmpty
-                    ? Text(
-                        data.description!,
-                        semanticsLabel: 'Event Description and Details: ${data.description}',
-                        style: TextStyle(fontSize: 16, height: 1.4, fontWeight: FontWeight.w400),
-                      )
-                    : Container(),
-              ],
-            )),
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            children: [
+              ///////////////// Horizontal Division ///////////////////
+              Divider(color: listTileDividerColorDark, thickness: 0.6),
+              // Event Description
+              data.description != null && data.description!.isNotEmpty
+                  ? Text(
+                      data.description!,
+                      semanticsLabel: 'Event Description and Details: ${data.description}',
+                      style: TextStyle(fontSize: 16, height: 1.4, fontWeight: FontWeight.w400),
+                    )
+                  : Container(),
+            ],
+          ),
+        ),
         Container(
           padding: EdgeInsets.only(left: 15, top: 5, right: 248, bottom: 20),
           // "GO TO EVENT PAGE" Button
           child: data.link != null && data.link!.isNotEmpty ? GoToEventPageButton(link: data.link!) : Container(),
-        )
+        ),
       ],
     );
   }
@@ -133,7 +141,7 @@ class EventImage extends StatelessWidget {
     String fallbackTitle = data.title;
     var isTitleTooLong = fallbackTitle.length > 40;
     if (isTitleTooLong) fallbackTitle = fallbackTitle.substring(0, 40) + '...';
-    String semanticLabel = data.imageAltText ?? fallbackTitle;
+    String semanticLabel = data.imageAltText?.trim().isNotEmpty == true ? data.imageAltText! : fallbackTitle;
 
     // Add spaces between consecutive uppercase letters so TalkBack spells acronyms out
     semanticLabel = semanticLabel.replaceAllMapped(


### PR DESCRIPTION
## Summary
2 line fix to ensure screen readers read the location from an event detail page.

The lines are:
67: Changed from `label: 'Location: '`, to `label: 'Location: ${data.location}'`,
144: Changed from  `String semanticLabel = data.imageAltText ?? fallbackTitle;` to `String semanticLabel = data.imageAltText?.trim().isNotEmpty == true ? data.imageAltText! : fallbackTitle;`


## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability to special events card
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[General] [Fix] - Expanded the existing 2 lines to handle empty locations (rare cases).


## Test Plan
These handle special cases like empty location, and these lines were directly suggested in the task description, so if there are no events with empty location, there's no need to wait for this to be tested and can safely be merged.
